### PR TITLE
Modified a few more tests

### DIFF
--- a/tests/CloudAMQP_test.py
+++ b/tests/CloudAMQP_test.py
@@ -11,7 +11,7 @@ channel = connection.channel() # start a channel
 channel.queue_declare(queue='hello') # Declare a queue
 ## channel.exchange_declare(exchange='amq.direct',
 ##                          exchange_type='direct')
-print '------------'
+print ('------------')
 channel.basic_publish(exchange='amq.direct',
                   routing_key='h',
                   body='Hello Mani!')

--- a/tests/multicore37test.py
+++ b/tests/multicore37test.py
@@ -1,67 +1,71 @@
 from multiprocessing import Process, Value, Array
-
-def f(n, a, b):
-    n.value = 3.1415927
-    for i in range(len(a)):
-        a[i] = -a[i]
-    for i in range(len(b)):
-        b[i] = 2*b[i]
-def g(n, l):
-    A, B = l
-    name_a, arr_a = A
-    name_b, arr_b = B
-    print ('names are ', name_a, name_b)    
-    f(n,arr_a,arr_b)
-
-def h(l):
-    A, B = l
-    name_a, arr_a = A
-    name_b, arr_b = B
-    print ('names are ', name_a, name_b)    
-    for i in range(len(arr_a)):
-        arr_a[i] = arr_a[i] * 100   
-    for i in range(len(arr_b)):
-        arr_b[i] = arr_b[i] * 1000
-    
-
-def test():
-    import numpy as np
-    num = Value('d', 0.0)
-    arr_a = Array('i', range(10))
-    arr_b = Array('i', range(10))
-    np_a = np.arange(10)
-    np_b = np.arange(10)
-    print ('num.value = ', num.value)
-    print ('arr_a[:] = ', arr_a[:])
-    print ('np_a[:] = ', np_a)
-    print ('np_b[:] = ', np_b)
-    l = [('a', np_a), ('b', np_b)]
-    l_arr = [('a', arr_a), ('b', arr_b)]
-
-    p = Process(target=g, args=(num, l,))
-    q = Process(target=h, args=(l,))
-    p.start()
-    q.start()
-    p.join()
-    q.join()
-
-    print('num.value = ', num.value)
-    print('np_a[:] = ', np_a[:])
-    print('np_b[:] = ', np_b[:])
+import unittest
 
 
+class test_multicore37(unittest.TestCase):
 
-    p = Process(target=g, args=(num, l_arr,))
-    q = Process(target=h, args=(l_arr,))
-    p.start()
-    q.start()
-    p.join()
-    q.join()
+    def f(self, n, a, b):
+        n.value = 3.1415927
+        for i in range(len(a)):
+            a[i] = -a[i]
+        for i in range(len(b)):
+            b[i] = 2*b[i]
+    def g(self, n, l):
+        A, B = l
+        name_a, arr_a = A
+        name_b, arr_b = B
+        print ('names are ', name_a, name_b)    
+        self.f(n,arr_a,arr_b)
 
-    print('num.value = ', num.value)
-    print('arr_a[:] = ', arr_a[:])
-    print('arr_b[:] = ', arr_b[:])
+    def h(self, l):
+        A, B = l
+        name_a, arr_a = A
+        name_b, arr_b = B
+        print ('names are ', name_a, name_b)    
+        for i in range(len(arr_a)):
+            arr_a[i] = arr_a[i] * 100   
+        for i in range(len(arr_b)):
+            arr_b[i] = arr_b[i] * 1000
+        
+
+    def test(self):
+        import numpy as np
+        num = Value('d', 0.0)
+        arr_a = Array('i', range(10))
+        arr_b = Array('i', range(10))
+        np_a = np.arange(10)
+        np_b = np.arange(10)
+        print ('num.value = ', num.value)
+        print ('arr_a[:] = ', arr_a[:])
+        print ('np_a[:] = ', np_a)
+        print ('np_b[:] = ', np_b)
+        l = [('a', np_a), ('b', np_b)]
+        l_arr = [('a', arr_a), ('b', arr_b)]
+
+        p = Process(target=self.g, args=(num, l,))
+        q = Process(target=self.h, args=(l,))
+        p.start()
+        q.start()
+        p.join()
+        q.join()
+
+        print('num.value = ', num.value)
+        print('np_a[:] = ', np_a[:])
+        print('np_b[:] = ', np_b[:])
+
+
+
+        p = Process(target=self.g, args=(num, l_arr,))
+        q = Process(target=self.h, args=(l_arr,))
+        p.start()
+        q.start()
+        p.join()
+        q.join()
+
+        print('num.value = ', num.value)
+        print('arr_a[:] = ', arr_a[:])
+        print('arr_b[:] = ', arr_b[:])
 
 
 if __name__ == '__main__':
-    test()
+    unittest.main()

--- a/tests/multicore_test.py
+++ b/tests/multicore_test.py
@@ -3,10 +3,10 @@ This module makes processes for a multicore application.
 It uses multiprocessing.Array to enable multiple processes to
 share access to streams efficiently.
 """
-import sys
-import os
 # Check whether the Python version is 2.x or 3.x
 # If it is 2.x import Queue. If 3.x then import queue.
+import sys
+
 is_py2 = sys.version[0] == '2'
 if is_py2:
     import Queue as queue
@@ -19,620 +19,673 @@ import multiprocessing
 import threading
 import time
 import json
-sys.path.append(os.path.abspath("../agent_types"))
-sys.path.append(os.path.abspath("../core"))
-sys.path.append(os.path.abspath("../helper_functions"))
-sys.path.append(os.path.abspath("../concurrency"))
+import unittest
 
 # stream is in core
-from stream import Stream
+from IoTPy.core.stream import Stream
 # sink, op, basics are in the agent_types
-from sink import stream_to_queue, sink_list
-from merge import zip_map
-from op import map_element
-from iot import iot
-from basics import map_e, sink_e, f_add
-from recent_values import recent_values
+from IoTPy.agent_types.sink import stream_to_queue, sink_list
+from IoTPy.agent_types.merge import zip_map
+from IoTPy.agent_types.op import map_element
+from IoTPy.agent_types.iot import iot
+from IoTPy.agent_types.basics import map_e, sink_e, f_add
+from IoTPy.helper_functions.recent_values import recent_values
 #from source import source_func
-from iot import iot
+# from iot import iot
 # multicore is in concurrency
-from multicore import copy_data_to_stream, finished_source
-from multicore import make_multicore_processes
-from multicore import get_processes
-from pika_publication_agent import PikaPublisher
-from pika_subscribe_agent import PikaSubscriber
+from IoTPy.concurrency.multicore import copy_data_to_stream, finished_source
+from IoTPy.concurrency.multicore import make_multicore_processes
+from IoTPy.concurrency.multicore import get_processes
+from IoTPy.concurrency.pika_publication_agent import PikaPublisher
+from IoTPy.concurrency.pika_subscribe_agent import PikaSubscriber
 # print_stream is in helper_functions
-from print_stream import print_stream
+from IoTPy.helper_functions.print_stream import print_stream
 
-#------------------------------------------------------------------
-def test_pika_subscriber():
-    """
-    Simple example
+class test_multicore(unittest.TestCase):
+    #------------------------------------------------------------------
+    def test_pika_subscriber(self):
+        """
+        Simple example
 
-    """
-    # Agent function for process named 'p0'
-    def f(in_streams, out_streams):
-        print_stream(in_streams[0], 'x')
+        """
+        # Agent function for process named 'p0'
+        def f(in_streams, out_streams):
+            print_stream(in_streams[0], 'x')
 
-    # Source thread target for source stream named 'x'.
-    def h(proc):
-        def callback(ch, method, properties, body):
-            json_data = json.loads(body)
-            proc.copy_stream(data=json_data, stream_name='x')
-        pika_subscriber = PikaSubscriber(
-            callback, routing_key='temperature',
-            exchange='publications', host='localhost')
-        pika_subscriber.start()
-
-
-    # The specification
-    multicore_specification = [
-        # Streams
-        [('x', 'i')],
-        # Processes
-        [
-            # Process p0
-            {'name': 'p0', 'agent': f, 'inputs':['x'], 'sources': ['x'],
-             'source_functions':[h]}
-        ]
-       ]
-
-    # Execute processes (after including your own non IoTPy processes)
-    processes = get_processes(multicore_specification)
-    for process in processes: process.start()
-    for process in processes: process.join()
-    for process in processes: process.terminate()
+        # Source thread target for source stream named 'x'.
+        def h(proc):
+            def callback(ch, method, properties, body):
+                json_data = json.loads(body)
+                proc.copy_stream(data=json_data, stream_name='x')
+            pika_subscriber = PikaSubscriber(
+                callback, routing_key='temperature',
+                exchange='publications', host='localhost')
+            pika_subscriber.start()
 
 
-def test_0_0():
-    """
-    Simple example
+        # The specification
+        multicore_specification = [
+            # Streams
+            [('x', 'i')],
+            # Processes
+            [
+                # Process p0
+                {'name': 'p0', 'agent': f, 'inputs':['x'], 'sources': ['x'],
+                 'source_functions':[h]}
+            ]
+           ]
 
-    """
-    # Agent function for process named 'p0'
-    def f(in_streams, out_streams):
-        map_element(lambda v: v+100, in_streams[0], out_streams[0])
-
-    # Agent function for process named 'p1'
-    def g(in_streams, out_streams):
-        s = Stream('s')
-        map_element(lambda v: v*2, in_streams[0], s)
-        print_stream(s, 's')
-
-    # Source thread target for source stream named 'x'.
-    def h(proc):
-        for i in range(2):
-            proc.copy_stream(data=list(range(i*3, (i+1)*3)),
-                             stream_name='x')
-            time.sleep(0.001)
-        proc.finished_source(stream_name='x')
-
-    # The specification
-    multicore_specification = [
-        # Streams
-        [('x', 'i'), ('y', 'i')],
-        # Processes
-        [
-            # Process p0
-            {'name': 'p0', 'agent': f, 'inputs':['x'], 'outputs': ['y'], 'sources': ['x'],
-             'source_functions':[h]},
-            # Process p1
-            {'name': 'p1', 'agent': g, 'inputs': ['y']}
-        ]
-       ]
-
-    # Execute processes (after including your own non IoTPy processes)
-    processes = get_processes(multicore_specification)
-    for process in processes: process.start()
-    for process in processes: process.join()
-    for process in processes: process.terminate()
-
-#------------------------------------------------------------------
-def test_0_1():
-    """
-    Same as test_0_0 except that in this example the source is
-    in process p1 and the source stream is read by process p0,
-    whereas in test_0_0 the source is in process p0.
-
-    """
-    # Agent function for process named 'p0'
-    def f(in_streams, out_streams):
-        map_element(lambda v: v+100, in_streams[0], out_streams[0])
-
-    # Agent function for process named 'p1'
-    def g(in_streams, out_streams):
-        s = Stream('s')
-        map_element(lambda v: v*2, in_streams[0], s)
-        print_stream(s, 's')
-
-    # Source thread target for source stream named 'x'.
-    def h(proc):
-        for i in range(2):
-            proc.copy_stream(data=list(range(i*3, (i+1)*3)),
-                             stream_name='x')
-            time.sleep(0.001)
-        proc.finished_source(stream_name='x')
-
-    # Specification
-    multicore_specification = [
-        # Streams
-        [('x', 'i'), ('y', 'i')],
-        # Processes
-        [
-            # Process p0
-            {'name': 'p0', 'agent': f, 'inputs':['x'], 'outputs': ['y']},
-            # Process p1
-            {'name': 'p1', 'agent': g, 'inputs': ['y'], 'sources': ['x'],
-             'source_functions':[h]}
-        ]
-       ]
-
-    # Execute processes (after including your own non IoTPy processes)
-    processes = get_processes(multicore_specification)
-    for process in processes: process.start()
-    for process in processes: process.join()
-    for process in processes: process.terminate()
+        # Execute processes (after including your own non IoTPy processes)
+        processes = get_processes(multicore_specification)
+        for process in processes: process.start()
+        for process in processes: process.join()
+        for process in processes: process.terminate()
 
 
-#------------------------------------------------------------------
-def test_q_simple():
-    """
-    Illustrates the use of an output queue and use of a non-IoTPy
-    thread.
-    When the IoTPy processes terminate execution a special message
-    '_finished' is put on each of the output queues.
-    The non-IoTPy thread, my_thread, gets data from the output queue
-    and prints it.
+    def test_0_0(self):
+        """
+        Simple example
 
-    """
+        """
+        # Agent function for process named 'p0'
+        print("Starting test_0_0")
+        def f(in_streams, out_streams):
+            map_element(lambda v: v+100, in_streams[0], out_streams[0])
 
-    # An output queue of process 'p1'.
-    q = multiprocessing.Queue()
+        # Agent function for process named 'p1'
+        def g(in_streams, out_streams):
+            s = Stream('s')
+            map_element(lambda v: v*2, in_streams[0], s)
+            print_stream(s, 's')
 
-    # Agent function for process named 'p0'
-    def f(in_streams, out_streams):
-        stream_to_queue(in_streams[0], q)
+        # Source thread target for source stream named 'x'.
+        def h(proc):
+            for i in range(2):
+                proc.copy_stream(data=list(range(i*3, (i+1)*3)),
+                                 stream_name='x')
+                time.sleep(0.001)
+            proc.finished_source(stream_name='x')
 
-    # Source thread target for source stream named 'x'.
-    def h(proc):
-        proc.copy_stream(data=list(range(5)), stream_name='x')
-        proc.finished_source(stream_name='x')
+        # The specification
+        multicore_specification = [
+            # Streams
+            [('x', 'i'), ('y', 'i')],
+            # Processes
+            [
+                # Process p0
+                {'name': 'p0', 'agent': f, 'inputs':['x'], 'outputs': ['y'], 'sources': ['x'],
+                 'source_functions':[h]},
+                # Process p1
+                {'name': 'p1', 'agent': g, 'inputs': ['y']}
+            ]
+           ]
 
-    # Output thread target
-    def publish_data_from_queue(q):
-        publisher = PikaPublisher(
-            routing_key='temperature',
-            exchange='publications', host='localhost')
-        while True:
-            v = q.get()
-            if v == '_finished': break
-            else: publisher.publish_list([v])
-    # Output thread
-    my_thread = threading.Thread(target=publish_data_from_queue, args=(q,))
-
-    # Specification
-    multicore_specification = [
-        # Streams
-        [('x', 'i')],
-        # Processes
-        [
-            # Process p0
-            {'name': 'p0', 'agent': f, 'inputs': ['x'],
-             'sources': ['x'], 'source_functions':[h], 'output_queues':[q],
-             'threads': [my_thread]
-            }
-        ]
-       ]
-
-    # Execute processes (after including your own non IoTPy processes)
-    processes = get_processes(multicore_specification)
-    for process in processes: process.start()
-    for process in processes: process.join()
-    for process in processes: process.terminate()
+        # Execute processes (after including your own non IoTPy processes)
+        processes = get_processes(multicore_specification)
+        for process in processes: process.start()
+        for process in processes: process.join()
+        for process in processes: process.terminate()
+        print('')
+        print ('--------------------------------------')
 
 
-#------------------------------------------------------------------
-def test_q_simple_1():
-    """
+    #------------------------------------------------------------------
+    def test_0_1(self):
+        """
+        Same as test_0_0 except that in this example the source is
+        in process p1 and the source stream is read by process p0,
+        whereas in test_0_0 the source is in process p0.
 
-    """
-    # Agent function for process named 'p0'
-    def f(in_streams, out_streams):
-        publisher = PikaPublisher(
-            routing_key='temperature',
-            exchange='publications', host='localhost')
-        sink_list(publisher.publish_list, in_streams[0])
+        """
+        # Agent function for process named 'p0'
+        print("Starting test_0_1")
+        def f(in_streams, out_streams):
+            map_element(lambda v: v+100, in_streams[0], out_streams[0])
 
-    # Source thread target for source stream named 'x'.
-    def h(proc):
-        proc.copy_stream(data=list(range(5000, 10000, 1000)), stream_name='x')
-        proc.finished_source(stream_name='x')
+        # Agent function for process named 'p1'
+        def g(in_streams, out_streams):
+            s = Stream('s')
+            map_element(lambda v: v*2, in_streams[0], s)
+            print_stream(s, 's')
 
-    # Specification
-    multicore_specification = [
-        # Streams
-        [('x', 'i')],
-        # Processes
-        [
-            # Process p0
-            {'name': 'p0', 'agent': f, 'inputs': ['x'],
-             'sources': ['x'], 'source_functions':[h]
-            }
-        ]
-       ]
+        # Source thread target for source stream named 'x'.
+        def h(proc):
+            for i in range(2):
+                proc.copy_stream(data=list(range(i*3, (i+1)*3)),
+                                 stream_name='x')
+                time.sleep(0.001)
+            proc.finished_source(stream_name='x')
 
-    # Execute processes (after including your own non IoTPy processes)
-    processes = get_processes(multicore_specification)
-    for process in processes: process.start()
-    for process in processes: process.join()
-    for process in processes: process.terminate()
+        # Specification
+        multicore_specification = [
+            # Streams
+            [('x', 'i'), ('y', 'i')],
+            # Processes
+            [
+                # Process p0
+                {'name': 'p0', 'agent': f, 'inputs':['x'], 'outputs': ['y']},
+                # Process p1
+                {'name': 'p1', 'agent': g, 'inputs': ['y'], 'sources': ['x'],
+                 'source_functions':[h]}
+            ]
+           ]
 
+        # Execute processes (after including your own non IoTPy processes)
+        processes = get_processes(multicore_specification)
+        for process in processes: process.start()
+        for process in processes: process.join()
+        for process in processes: process.terminate()
+        print('')
+        print ('--------------------------------------')
+
+
+
+    #------------------------------------------------------------------
+    def test_q_simple(self):
+        """
+        Illustrates the use of an output queue and use of a non-IoTPy
+        thread.
+        When the IoTPy processes terminate execution a special message
+        '_finished' is put on each of the output queues.
+        The non-IoTPy thread, my_thread, gets data from the output queue
+        and prints it.
+
+        """
+        print ('starting test_q_simple')
+
+        # An output queue of process 'p1'.
+        q = multiprocessing.Queue()
+
+        # Agent function for process named 'p0'
+        def f(in_streams, out_streams):
+            stream_to_queue(in_streams[0], q)
+
+        # Source thread target for source stream named 'x'.
+        def h(proc):
+            proc.copy_stream(data=list(range(5)), stream_name='x')
+            proc.finished_source(stream_name='x')
+
+        # Output thread target
+        def publish_data_from_queue(q):
+            publisher = PikaPublisher(
+                routing_key='temperature',
+                exchange='publications', host='localhost')
+            while True:
+                v = q.get()
+                if v == '_finished': break
+                else: publisher.publish_list([v])
+        # Output thread
+        my_thread = threading.Thread(target=publish_data_from_queue, args=(q,))
+
+        # Specification
+        multicore_specification = [
+            # Streams
+            [('x', 'i')],
+            # Processes
+            [
+                # Process p0
+                {'name': 'p0', 'agent': f, 'inputs': ['x'],
+                 'sources': ['x'], 'source_functions':[h], 'output_queues':[q],
+                 'threads': [my_thread]
+                }
+            ]
+           ]
+
+        # Execute processes (after including your own non IoTPy processes)
+        processes = get_processes(multicore_specification)
+        for process in processes: process.start()
+        for process in processes: process.join()
+        for process in processes: process.terminate()
+
+        print('')
+        print ('--------------------------------------')
+
+
+    #------------------------------------------------------------------
+    def test_q_simple_1(self):
+        """
         
+        """
+        # Agent function for process named 'p0'
+        print ('starting test_q_simple')
 
-#------------------------------------------------------------------
-def test_1_q():
-    """
-    Illustrates the use of an output queue and use of a non-IoTPy
-    thread.
-    When the IoTPy processes terminate execution a special message
-    '_finished' is put on each of the output queues.
-    The non-IoTPy thread, my_thread, gets data from the output queue
-    and prints it.
+        def f(in_streams, out_streams):
+            publisher = PikaPublisher(
+                routing_key='temperature',
+                exchange='publications', host='localhost')
+            sink_list(publisher.publish_list, in_streams[0])
 
-    """
+        # Source thread target for source stream named 'x'.
+        def h(proc):
+            proc.copy_stream(data=list(range(5000, 10000, 1000)), stream_name='x')
+            proc.finished_source(stream_name='x')
 
-    # An output queue of process 'p1'.
-    q = multiprocessing.Queue()
+        # Specification
+        multicore_specification = [
+            # Streams
+            [('x', 'i')],
+            # Processes
+            [
+                # Process p0
+                {'name': 'p0', 'agent': f, 'inputs': ['x'],
+                 'sources': ['x'], 'source_functions':[h]
+                }
+            ]
+           ]
 
-    # Agent function for process named 'p0'
-    def f(in_streams, out_streams):
-        map_element(lambda v: v+100, in_streams[0], out_streams[0])
+        # Execute processes (after including your own non IoTPy processes)
+        processes = get_processes(multicore_specification)
+        for process in processes: process.start()
+        for process in processes: process.join()
+        for process in processes: process.terminate()
+        print('')
+        print ('--------------------------------------')
 
-    # Agent function for process named 'p1'
-    # Puts stream into output queue, q.
-    def g(in_streams, out_streams, q):
-        s = Stream('s')
-        map_element(lambda v: v*2, in_streams[0], s)
-        stream_to_queue(s, q)
+            
 
-    # Source thread target for source stream named 'x'.
-    def h(proc):
-        for i in range(2):
-            proc.copy_stream(data=list(range(i*3, (i+1)*3)),
-                             stream_name='x')
-            time.sleep(0.001)
-        proc.finished_source(stream_name='x')
+    #------------------------------------------------------------------
+    def test_1_q(self):
+        """
+        Illustrates the use of an output queue and use of a non-IoTPy
+        thread.
+        When the IoTPy processes terminate execution a special message
+        '_finished' is put on each of the output queues.
+        The non-IoTPy thread, my_thread, gets data from the output queue
+        and prints it.
 
-    # Thread that gets data from the output queue
-    # This thread is included in 'threads' in the specification.
-    # Thread target
-    def publish_data_from_queue(q):
-        publisher = PikaPublisher(
-            routing_key='temperature',
-            exchange='publications', host='localhost')
-        finished = False
-        while not finished:
-            list_to_be_published = []
+        """
+        print ('starting test_1_q')
+
+        # An output queue of process 'p1'.
+        q = multiprocessing.Queue()
+
+        # Agent function for process named 'p0'
+        def f(in_streams, out_streams):
+            map_element(lambda v: v+100, in_streams[0], out_streams[0])
+
+        # Agent function for process named 'p1'
+        # Puts stream into output queue, q.
+        def g(in_streams, out_streams, q):
+            s = Stream('s')
+            map_element(lambda v: v*2, in_streams[0], s)
+            stream_to_queue(s, q)
+
+        # Source thread target for source stream named 'x'.
+        def h(proc):
+            for i in range(2):
+                proc.copy_stream(data=list(range(i*3, (i+1)*3)),
+                                 stream_name='x')
+                time.sleep(0.001)
+            proc.finished_source(stream_name='x')
+
+        # Thread that gets data from the output queue
+        # This thread is included in 'threads' in the specification.
+        # Thread target
+        def publish_data_from_queue(q):
+            publisher = PikaPublisher(
+                routing_key='temperature',
+                exchange='publications', host='localhost')
+            finished = False
             while not finished:
-                try:
-                    v = q.get(timeout=0.1)
-                    if v == '_finished':
-                        finished = True
+                list_to_be_published = []
+                while not finished:
+                    try:
+                        v = q.get(timeout=0.1)
+                        if v == '_finished':
+                            finished = True
+                            if list_to_be_published:
+                                publisher.publish_list(list_to_be_published)
+                        else:
+                            list_to_be_published.append(v)
+                    except:
+                        print ('from queue: list_to_be_published is ', list_to_be_published)
                         if list_to_be_published:
                             publisher.publish_list(list_to_be_published)
-                    else:
-                        list_to_be_published.append(v)
-                except:
-                    print ('from queue: list_to_be_published is ', list_to_be_published)
-                    if list_to_be_published:
-                        publisher.publish_list(list_to_be_published)
-                        list_to_be_published = []
-    # Output thread
-    my_thread = threading.Thread(target=publish_data_from_queue, args=(q,))
+                            list_to_be_published = []
+        # Output thread
+        my_thread = threading.Thread(target=publish_data_from_queue, args=(q,))
 
-    # Specification
-    # Agent function g of process p1 has a positional argument q becauses
-    # 'args': [q] is in the specification for p1.
-    # q is an output queue because 'output_queues': [q] appears in the spec.
-    # When the IoTPy computation terminates, a special message '_finished' is
-    # put on each output queue.
-    multicore_specification = [
-        # Streams
-        [('x', 'i'), ('y', 'i')],
-        # Processes
-        [
-            # Process p0
-            {'name': 'p0', 'agent': f, 'inputs': ['x'], 'outputs': ['y'],
-             'sources': ['x'], 'source_functions':[h]
-            },
-            # Process p1
-            {'name': 'p1', 'agent': g, 'inputs': ['y'], 'args': [q],
-             'output_queues': [q], 'threads': [my_thread] }
-        ]
-       ]
+        # Specification
+        # Agent function g of process p1 has a positional argument q becauses
+        # 'args': [q] is in the specification for p1.
+        # q is an output queue because 'output_queues': [q] appears in the spec.
+        # When the IoTPy computation terminates, a special message '_finished' is
+        # put on each output queue.
+        multicore_specification = [
+            # Streams
+            [('x', 'i'), ('y', 'i')],
+            # Processes
+            [
+                # Process p0
+                {'name': 'p0', 'agent': f, 'inputs': ['x'], 'outputs': ['y'],
+                 'sources': ['x'], 'source_functions':[h]
+                },
+                # Process p1
+                {'name': 'p1', 'agent': g, 'inputs': ['y'], 'args': [q],
+                 'output_queues': [q], 'threads': [my_thread] }
+            ]
+           ]
 
-    # Execute processes (after including your own non IoTPy processes)
-    processes = get_processes(multicore_specification)
-    for process in processes: process.start()
-    for process in processes: process.join()
+        # Execute processes (after including your own non IoTPy processes)
+        processes = get_processes(multicore_specification)
+        for process in processes: process.start()
+        for process in processes: process.join()
 
-    
-
-#------------------------------------------------------------------
-def test_1():
-    """
-    Illustrates the use of an output queue and use of a non-IoTPy
-    thread.
-    When the IoTPy processes terminate execution a special message
-    '_finished' is put on each of the output queues.
-    The non-IoTPy thread, my_thread, gets data from the output queue
-    and prints it.
-
-    """
-    # An output queue of process 'p1'.
-    q = multiprocessing.Queue()
-
-    # Agent function for process named 'p0'
-    def f(in_streams, out_streams):
-        map_element(lambda v: v+100, in_streams[0], out_streams[0])
-
-    # Agent function for process named 'p1'
-    # Puts stream into output queue, q.
-    def g(in_streams, out_streams, q):
-        s = Stream('s')
-        map_element(lambda v: v*2, in_streams[0], s)
-        stream_to_queue(s, q)
-
-    # Source thread target for source stream named 'x'.
-    def h(proc):
-        for i in range(2):
-            proc.copy_stream(data=list(range(i*3, (i+1)*3)),
-                             stream_name='x')
-            time.sleep(0.001)
-        proc.finished_source(stream_name='x')
-
-    # Thread that gets data from the output queue
-    # This thread is included in 'threads' in the specification.
-    # Thread target
-    def get_data_from_output_queue(q):
-        while True:
-            v = q.get()
-            if v == '_finished':
-                break
-            print ('from queue: ', v)
-    # Thread
-    my_thread = threading.Thread(target=get_data_from_output_queue, args=(q,))
-
-    # Specification
-    # Agent function g of process p1 has a positional argument q becauses
-    # 'args': [q] is in the specification for p1.
-    # q is an output queue because 'output_queues': [q] appears in the spec.
-    # When the IoTPy computation terminates, a special message '_finished' is
-    # put on each output queue.
-    multicore_specification = [
-        # Streams
-        [('x', 'i'), ('y', 'i')],
-        # Processes
-        [
-            # Process p0
-            {'name': 'p0', 'agent': f, 'inputs': ['x'], 'outputs': ['y'],
-             'sources': ['x'], 'source_functions':[h]
-            },
-            # Process p1
-            {'name': 'p1', 'agent': g, 'inputs': ['y'], 'args': [q],
-             'output_queues': [q], 'threads': [my_thread] }
-        ]
-       ]
-
-    # Execute processes (after including your own non IoTPy processes)
-    processes = get_processes(multicore_specification)
-    for process in processes: process.start()
-    for process in processes: process.join()
-    for process in processes: process.terminate()
-
-    
-def test_parameter(ADDEND_VALUE):
-    """
-    Illustrates the use of args which is also illustrated in test_1.
-    This example is a small modification of test_0_0.
-
-    """
-    # Agent function for process named 'p0'
-    # ADDEND is a positional argument of f in the spec for p0.
-    def f(in_streams, out_streams, ADDEND):
-        map_element(lambda v: v+ADDEND, in_streams[0], out_streams[0])
-
-    # Agent function for process named 'p1'
-    def g(in_streams, out_streams):
-        s = Stream('s')
-        map_element(lambda v: v*2, in_streams[0], s)
-        print_stream(s, 's')
-
-    # Source thread target for source stream named 'x'.
-    def h(proc):
-        for i in range(2):
-            proc.copy_stream(data=list(range(i*3, (i+1)*3)),
-                             stream_name='x')
-            time.sleep(0.001)
-        proc.finished_source(stream_name='x')
-
-    # Specification
-    multicore_specification = [
-        # Streams
-        [('x', 'i'), ('y', 'i')],
-        # Processes
-        [
-            # Process p0
-            {'name': 'p0', 'agent': f, 'inputs':['x'], 'outputs': ['y'],
-             'args': [ADDEND_VALUE], 'sources': ['x'], 'source_functions':[h]},
-            # Process p1
-            {'name': 'p1', 'agent': g, 'inputs': ['y'], }
-        ]
-       ]
-
-    # Execute processes (after including your own non IoTPy processes)
-    processes = get_processes(multicore_specification)
-    for process in processes: process.start()
-    for process in processes: process.join()
-    for process in processes: process.terminate()
-
-#-------------------------------------------------------------
-def test_parameter_result():
-    """
-    This example illustrates how you can get results from IoTPy processes when the
-    processes terminate. The results are stored in a buffer (a multiprocessing.Array)
-    which your non-IoTPy code can read. You can insert data into the IoTPy processes
-    continuously or before the processes are started.
-
-    In this example output_buffer[j] = 0 + 1 + 2 + ... + j
-
-    """
-    # The results of the parallel computation are stored in output_buffer.
-    output_buffer = multiprocessing.Array('i', 20)
-    # The results are in output_buffer[:output_buffer_ptr]
-    output_buffer_ptr = multiprocessing.Value('i', 0)
-
-    # In this example v represents an element of an input stream.
-    # sum is the sum of all the stream-element values received
-    # by the agent. The state of the agent is sum.
-    # output_buffer and output_buffer_ptr are keyword arguments.
-    @map_e
-    def ff(v, sum, output_buffer, output_buffer_ptr):
-        sum += v
-        output_buffer[output_buffer_ptr.value] = sum
-        output_buffer_ptr.value +=1
-        return sum, sum
-
-    # Agent function for process named 'p0'
-    def f(in_streams, out_streams, output_buffer, output_buffer_ptr):
-        ff(in_streams[0], out_streams[0], state=0,
-           output_buffer=output_buffer, output_buffer_ptr=output_buffer_ptr)
-        #print_stream(in_streams[0], 'gg_in_streams[0]')
-        #print_stream(out_streams[0], 'gg_out_streams[0]')
-
-    # Agent function for process named 'p1'
-    def g(in_streams, out_streams):
-        s = Stream('s')
-        map_element(lambda v: v*2, in_streams[0], s)
-        print_stream(s, 's')
-
-    # Source thread target for source stream named 'x'.
-    def h(proc):
-        for i in range(2):
-            proc.copy_stream(data=list(range(i*3, (i+1)*3)),
-                             stream_name='x')
-            time.sleep(0.001)
-        proc.finished_source(stream_name='x')
-
-    # Specification
-    multicore_specification = [
-        # Streams
-        [('x', 'i'), ('y', 'i')],
-        # Processes
-        [  # Process p0
-            {'name': 'p0', 'agent': f, 'inputs':['x'], 'outputs': ['y'],
-            'keyword_args' : {'output_buffer' : output_buffer,
-                              'output_buffer_ptr' : output_buffer_ptr},
-             'sources': ['x'], 'source_functions':[h]},
-            # Process p1
-            {'name': 'p1', 'agent': g, 'inputs': ['y'], } ]]
-
-    # Execute processes (after including your own non IoTPy processes)
-    processes = get_processes(multicore_specification)
-    for process in processes: process.start()
-    for process in processes: process.join()
-    for process in processes: process.terminate()
-
-    # Verify that output_buffer can be read by the parent process.
-    print ('output_buffer is ', output_buffer[:output_buffer_ptr.value])
+        print('')
+        print ('--------------------------------------')
 
 
-def test_echo():
-    """
-    This example illustrates a circular flow structure of
-    streams between processes. Process p0 feeds process p1,
-    and p1 feeds p0. This example shows a process (p0) with
-    2 input streams.
+    #------------------------------------------------------------------
+    def test_1(self):
+        """
+        Illustrates the use of an output queue and use of a non-IoTPy
+        thread.
+        When the IoTPy processes terminate execution a special message
+        '_finished' is put on each of the output queues.
+        The non-IoTPy thread, my_thread, gets data from the output queue
+        and prints it.
 
-    The example also illustrates the use of args and keyword_args
-    as well as output queues and threads, see q and my_thread.
+        """
+        # An output queue of process 'p1'.
+        print('Starting test_1')
+        q = multiprocessing.Queue()
 
-    The example is from making an echo to a sound, and then
-    generating the heard sound which is the made sound plus
-    the echo. See IoTPy/examples/acoustics. The key point
-    of the example is to show how processes are connected;
-    the acoustics part is not important for this illustration
-    of a multicore application.
+        # Agent function for process named 'p0'
+        def f(in_streams, out_streams):
+            map_element(lambda v: v+100, in_streams[0], out_streams[0])
 
-    """
-    # This is the delay from when the made sound hits a
-    # reflecting surface.
-    delay = 4
-    # This is the attenuation of the reflected wave.
-    attenuation = 0.5
-    # The results are put in this queue.
-    q = multiprocessing.Queue()
+        # Agent function for process named 'p1'
+        # Puts stream into output queue, q.
+        def g(in_streams, out_streams, q):
+            s = Stream('s')
+            map_element(lambda v: v*2, in_streams[0], s)
+            stream_to_queue(s, q)
 
-    # Agent function for process named 'p0'
-    # This agent zips the sound made with the echo
-    # to produce the sound heard.
-    def f(in_streams, out_streams, delay):
-        sound_made, echo = in_streams
-        echo.extend([0] * delay)
-        # The zip_map output is the sound heard which is
-        # the sound heard plus the echo.
-        zip_map(sum, [sound_made, echo], out_streams[0])
+        # Source thread target for source stream named 'x'.
+        def h(proc):
+            for i in range(2):
+                proc.copy_stream(data=list(range(i*3, (i+1)*3)),
+                                 stream_name='x')
+                time.sleep(0.001)
+            proc.finished_source(stream_name='x')
 
-    # Agent function for process named 'p1'
-    # This process puts the sound heard into the output queue
-    #  and returns the echo as an output stream.
-    def g(in_streams, out_streams, attenuation, q):
-        def gg(v):
-            # v is the sound heard
-            q.put(v)
-            # v*attenuation is the echo
-            return v*attenuation
-        map_element(
-            gg, in_streams[0], out_streams[0])
+        # Thread that gets data from the output queue
+        # This thread is included in 'threads' in the specification.
+        # Thread target
+        def get_data_from_output_queue(q):
+            while True:
+                v = q.get()
+                if v == '_finished':
+                    break
+                print ('from queue: ', v)
+        # Thread
+        my_thread = threading.Thread(target=get_data_from_output_queue, args=(q,))
 
-    # Source thread target for source stream named 'sound_made'.
-    # In this test sound made is [0, 1,..., 9, 0, 0, ...., 0]
-    def h(proc):
-        proc.copy_stream(data=list(range(10)), stream_name='sound_made')
-        time.sleep(0.1)
-        proc.copy_stream(data=([0]*10), stream_name='sound_made')
-        proc.finished_source(stream_name='sound_made')
-        return
+        # Specification
+        # Agent function g of process p1 has a positional argument q becauses
+        # 'args': [q] is in the specification for p1.
+        # q is an output queue because 'output_queues': [q] appears in the spec.
+        # When the IoTPy computation terminates, a special message '_finished' is
+        # put on each output queue.
+        multicore_specification = [
+            # Streams
+            [('x', 'i'), ('y', 'i')],
+            # Processes
+            [
+                # Process p0
+                {'name': 'p0', 'agent': f, 'inputs': ['x'], 'outputs': ['y'],
+                 'sources': ['x'], 'source_functions':[h]
+                },
+                # Process p1
+                {'name': 'p1', 'agent': g, 'inputs': ['y'], 'args': [q],
+                 'output_queues': [q], 'threads': [my_thread] }
+            ]
+           ]
 
-    # Thread that gets data from the output queue
-    # This thread is included in 'threads' in the specification.
-    # Thread target
-    def get_data_from_output_queue(q):
-        finished_getting_output = False
-        while not finished_getting_output:
-            v = q.get()
-            if v == '_finished':
-                break
-            print ('from queue: ', v)
-    # Thread
-    my_thread = threading.Thread(target=get_data_from_output_queue, args=(q,))
+        # Execute processes (after including your own non IoTPy processes)
+        processes = get_processes(multicore_specification)
+        for process in processes: process.start()
+        for process in processes: process.join()
+        for process in processes: process.terminate()
+        print('')
+        print ('--------------------------------------')
 
-    multicore_specification = [
-        # Streams
-        [('sound_made', 'f'), ('echo', 'f'), ('sound_heard', 'f')],
-        # Processes
-        [# Process p0
-         {'name': 'p0', 'agent': f, 'inputs': ['sound_made', 'echo'], 'outputs': ['sound_heard'],
-          'keyword_args' : {'delay' : delay}, 'sources': ['sound_made'], 'source_functions':[h]},
-         # Process p1
-         {'name': 'p1', 'agent': g, 'inputs': ['sound_heard'], 'outputs': ['echo'],
-          'args': [attenuation, q], 'output_queues': [q], 'threads': [my_thread] } ]]
 
-    # Execute processes (after including your own non IoTPy processes)
-    processes = get_processes(multicore_specification)
-    for process in processes: process.start()
-    for process in processes: process.join()
-    for process in processes: process.terminate()
+        
+    def test_parameter(self, ADDEND_VALUE=500):
+        """
+        Illustrates the use of args which is also illustrated in test_1.
+        This example is a small modification of test_0_0.
+
+        """
+        # Agent function for process named 'p0'
+        # ADDEND is a positional argument of f in the spec for p0.
+        print ('starting test_parameter')
+        print ('')
+        print ('Output printed are values of stream s. See function g')
+        print ('s[j] = 500 + j + 100, because the ADDEND is 500 and')
+        print ('increment adds 1 + 100')
+        print ('')
+
+        def f(in_streams, out_streams, ADDEND):
+            map_element(lambda v: v+ADDEND, in_streams[0], out_streams[0])
+
+        # Agent function for process named 'p1'
+        def g(in_streams, out_streams):
+            s = Stream('s')
+            map_element(lambda v: v*2, in_streams[0], s)
+            print_stream(s, 's')
+
+        # Source thread target for source stream named 'x'.
+        def h(proc):
+            for i in range(2):
+                proc.copy_stream(data=list(range(i*3, (i+1)*3)),
+                                 stream_name='x')
+                time.sleep(0.001)
+            proc.finished_source(stream_name='x')
+
+        # Specification
+        multicore_specification = [
+            # Streams
+            [('x', 'i'), ('y', 'i')],
+            # Processes
+            [
+                # Process p0
+                {'name': 'p0', 'agent': f, 'inputs':['x'], 'outputs': ['y'],
+                 'args': [ADDEND_VALUE], 'sources': ['x'], 'source_functions':[h]},
+                # Process p1
+                {'name': 'p1', 'agent': g, 'inputs': ['y'], }
+            ]
+           ]
+
+        # Execute processes (after including your own non IoTPy processes)
+        processes = get_processes(multicore_specification)
+        for process in processes: process.start()
+        for process in processes: process.join()
+        for process in processes: process.terminate()
+        print('')
+        print ('----------------------------')
+
+    #-------------------------------------------------------------
+    def test_parameter_result(self):
+        """
+        This example illustrates how you can get results from IoTPy processes when the
+        processes terminate. The results are stored in a buffer (a multiprocessing.Array)
+        which your non-IoTPy code can read. You can insert data into the IoTPy processes
+        continuously or before the processes are started.
+
+        In this example output_buffer[j] = 0 + 1 + 2 + ... + j
+
+        """
+        print ('starting test_parameter_result')
+        print ('')
+        print ('Output stream s and output_buffer.')
+        print ('output_buffer is [0, 1, 3, 6, 10, .., 45]')
+        print ('s[j] = output_buffer[j] + 100')
+        print ('')
+
+        # The results of the parallel computation are stored in output_buffer.
+        output_buffer = multiprocessing.Array('i', 20)
+        # The results are in output_buffer[:output_buffer_ptr]
+        output_buffer_ptr = multiprocessing.Value('i', 0)
+
+        # In this example v represents an element of an input stream.
+        # sum is the sum of all the stream-element values received
+        # by the agent. The state of the agent is sum.
+        # output_buffer and output_buffer_ptr are keyword arguments.
+        @map_e
+        def ff(v, sum, output_buffer, output_buffer_ptr):
+            sum += v
+            output_buffer[output_buffer_ptr.value] = sum
+            output_buffer_ptr.value +=1
+            return sum, sum
+
+        # Agent function for process named 'p0'
+        def f(in_streams, out_streams, output_buffer, output_buffer_ptr):
+            ff(in_streams[0], out_streams[0], state=0,
+               output_buffer=output_buffer, output_buffer_ptr=output_buffer_ptr)
+            #print_stream(in_streams[0], 'gg_in_streams[0]')
+            #print_stream(out_streams[0], 'gg_out_streams[0]')
+
+        # Agent function for process named 'p1'
+        def g(in_streams, out_streams):
+            s = Stream('s')
+            map_element(lambda v: v*2, in_streams[0], s)
+            print_stream(s, 's')
+
+        # Source thread target for source stream named 'x'.
+        def h(proc):
+            for i in range(2):
+                proc.copy_stream(data=list(range(i*3, (i+1)*3)),
+                                 stream_name='x')
+                time.sleep(0.001)
+            proc.finished_source(stream_name='x')
+
+        # Specification
+        multicore_specification = [
+            # Streams
+            [('x', 'i'), ('y', 'i')],
+            # Processes
+            [  # Process p0
+                {'name': 'p0', 'agent': f, 'inputs':['x'], 'outputs': ['y'],
+                'keyword_args' : {'output_buffer' : output_buffer,
+                                  'output_buffer_ptr' : output_buffer_ptr},
+                 'sources': ['x'], 'source_functions':[h]},
+                # Process p1
+                {'name': 'p1', 'agent': g, 'inputs': ['y'], } ]]
+
+        # Execute processes (after including your own non IoTPy processes)
+        processes = get_processes(multicore_specification)
+        for process in processes: process.start()
+        for process in processes: process.join()
+        for process in processes: process.terminate()
+
+        # Verify that output_buffer can be read by the parent process.
+        print ('output_buffer is ', output_buffer[:output_buffer_ptr.value])
+        print('')
+        print('')
+        print('')
+        print ('--------------------------------------')
+
+
+
+    def test_echo(self):
+        """
+        This example illustrates a circular flow structure of
+        streams between processes. Process p0 feeds process p1,
+        and p1 feeds p0. This example shows a process (p0) with
+        2 input streams.
+
+        The example also illustrates the use of args and keyword_args
+        as well as output queues and threads, see q and my_thread.
+
+        The example is from making an echo to a sound, and then
+        generating the heard sound which is the made sound plus
+        the echo. See IoTPy/examples/acoustics. The key point
+        of the example is to show how processes are connected;
+        the acoustics part is not important for this illustration
+        of a multicore application.
+
+        """
+        # This is the delay from when the made sound hits a
+        # reflecting surface.
+        print ('starting test_echo')
+        print ('delay = 4, attenuation = 0.5, spoken=[0,1,2,...,9]')
+        print ('')
+        print ('For 0 <= j < 4 : q[j] = j')
+        print ('For 4 <= j < 10: q[j] = j + q[j-4]*0.5')
+        print ('For 10 <=j : q[j] = q[j-4]*0.5')
+        print('')
+
+        delay = 4
+        # This is the attenuation of the reflected wave.
+        attenuation = 0.5
+        # The results are put in this queue.
+        q = multiprocessing.Queue()
+
+        # Agent function for process named 'p0'
+        # This agent zips the sound made with the echo
+        # to produce the sound heard.
+        def f(in_streams, out_streams, delay):
+            sound_made, echo = in_streams
+            echo.extend([0] * delay)
+            # The zip_map output is the sound heard which is
+            # the sound heard plus the echo.
+            zip_map(sum, [sound_made, echo], out_streams[0])
+
+        # Agent function for process named 'p1'
+        # This process puts the sound heard into the output queue
+        #  and returns the echo as an output stream.
+        def g(in_streams, out_streams, attenuation, q):
+            def gg(v):
+                # v is the sound heard
+                q.put(v)
+                # v*attenuation is the echo
+                return v*attenuation
+            map_element(
+                gg, in_streams[0], out_streams[0])
+
+        # Source thread target for source stream named 'sound_made'.
+        # In this test sound made is [0, 1,..., 9, 0, 0, ...., 0]
+        def h(proc):
+            proc.copy_stream(data=list(range(10)), stream_name='sound_made')
+            time.sleep(0.1)
+            proc.copy_stream(data=([0]*10), stream_name='sound_made')
+            proc.finished_source(stream_name='sound_made')
+            return
+
+        # Thread that gets data from the output queue
+        # This thread is included in 'threads' in the specification.
+        # Thread target
+        def get_data_from_output_queue(q):
+            finished_getting_output = False
+            while not finished_getting_output:
+                v = q.get()
+                if v == '_finished':
+                    break
+                print ('from queue: ', v)
+        # Thread
+        my_thread = threading.Thread(target=get_data_from_output_queue, args=(q,))
+
+        multicore_specification = [
+            # Streams
+            [('sound_made', 'f'), ('echo', 'f'), ('sound_heard', 'f')],
+            # Processes
+            [# Process p0
+             {'name': 'p0', 'agent': f, 'inputs': ['sound_made', 'echo'], 'outputs': ['sound_heard'],
+              'keyword_args' : {'delay' : delay}, 'sources': ['sound_made'], 'source_functions':[h]},
+             # Process p1
+             {'name': 'p1', 'agent': g, 'inputs': ['sound_heard'], 'outputs': ['echo'],
+              'args': [attenuation, q], 'output_queues': [q], 'threads': [my_thread] } ]]
+
+        # Execute processes (after including your own non IoTPy processes)
+        processes = get_processes(multicore_specification)
+        for process in processes: process.start()
+        for process in processes: process.join()
+        for process in processes: process.terminate()
+        print('')
+        print ('--------------------------------------')
+
 
 
 def multicore_example_v1(DATA, ADDEND, MULTIPLICAND, EXPONENT):
@@ -729,7 +782,7 @@ def multicore_example_v1(DATA, ADDEND, MULTIPLICAND, EXPONENT):
     # Get the results returned in the buffer.
     print ('buffer is ', buffer[:ptr.value])
 
-def multicore_example_v2(DATA, ADDEND, MULTIPLICAND, EXPONENT):
+def multicore_example_v2( DATA, ADDEND, MULTIPLICAND, EXPONENT):
     """
     This example illustrates integrating processes running non-IoTPy
     code with processes running IoTPy. The example shows how
@@ -836,58 +889,7 @@ def multicore_example_v2(DATA, ADDEND, MULTIPLICAND, EXPONENT):
     print ('buffer is ', buffer[:ptr.value])
         
 if __name__ == '__main__':
-    print ('starting test_q_simple_1')
-    test_q_simple_1()
-    print('')
-    print ('--------------------------------------')
-    print ('starting test_q_simple')
-    test_q_simple()
-    print('')
-    print ('--------------------------------------')
-    print ('starting test_1_q')
-    test_1_q()
-    print ('')
-    print ('starting test_0_0')
-    test_0_0()
-    print ('')
-    print ('starting test_0_1')
-    test_0_1()
-    print ('')
-    print ('starting test_1')
-    test_1()
-    print('')
-    print ('--------------------------------------')
-    print ('starting test_parameter')
-    print ('')
-    print ('Output printed are values of stream s. See function g')
-    print ('s[j] = 500 + j + 100, because the ADDEND is 500 and')
-    print ('increment adds 1 + 100')
-    print ('')
-    test_parameter(500)
-    print('')
-    print ('----------------------------')
-    print('')
-    print ('starting test_parameter_result')
-    print ('')
-    print ('Output stream s and output_buffer.')
-    print ('output_buffer is [0, 1, 3, 6, 10, .., 45]')
-    print ('s[j] = output_buffer[j] + 100')
-    print ('')
-    test_parameter_result()
-    print('')
-    print('')
-    print('')
-    print ('--------------------------------------')
-    print ('starting test_echo')
-    print ('delay = 4, attenuation = 0.5, spoken=[0,1,2,...,9]')
-    print ('')
-    print ('For 0 <= j < 4 : q[j] = j')
-    print ('For 4 <= j < 10: q[j] = j + q[j-4]*0.5')
-    print ('For 10 <=j : q[j] = q[j-4]*0.5')
-    print('')
-    test_echo()
-    print('')
-    print ('--------------------------------------')
+    # unittest.main()
     print ('starting multicore_example v1')
     print ('')
     print ('q[j] = (j+ADDEND)*MULTIPLICAND')

--- a/tests/multithread_test.py
+++ b/tests/multithread_test.py
@@ -18,170 +18,161 @@ import numpy as np
 import time
 import ntplib
 import logging
-
-sys.path.append("../core")
-sys.path.append("../agent_types")
-sys.path.append("../helper_functions")
-sys.path.append("../../examples/timing")
-sys.path.append("../concurrency")
-
+import unittest
 #from new import *
-from multicore import *
-from basics import map_e, map_l, map_w, merge_e,  merge_sink_e
-from basics import f_mul, f_add
+from IoTPy.concurrency.multicore import *
+from IoTPy.agent_types.basics import map_e, map_l, map_w, merge_e,  merge_sink_e
+from IoTPy.agent_types.basics import f_mul, f_add
 #from run import run
-from stream import StreamArray, run
-from multithread import thread_target_extending
-from multithread import thread_target_appending
-from recent_values import recent_values
-from sink import stream_to_queue
-from op import map_element
+from IoTPy.core.stream import StreamArray, run
+from IoTPy.concurrency.multithread import thread_target_extending
+from IoTPy.concurrency.multithread import thread_target_appending
+from IoTPy.helper_functions.recent_values import recent_values
+from IoTPy.agent_types.sink import stream_to_queue
+from IoTPy.agent_types.op import map_element
 #from run import run
 
-def output_thread_target(q_out, output, finished):
-    while True:
-        try:
-            w = q_out.get()
-            if w == finished: break
-            else: output.append(w)
-        except:
-            time.sleep(0.0001)
-    
-def test_multithread_1_1():
+class test_multithread(unittest.TestCase):
+    def output_thread_target(self, q_out, output, finished):
+        while True:
+            try:
+                w = q_out.get()
+                if w == finished: break
+                else: output.append(w)
+            except:
+                time.sleep(0.0001)
+        
+    def test_multithread_1_1(self):
 
-    # Agent functions
-    @merge_sink_e
-    def f(list_of_elements, q_out):
-            q_out.put(sum(list_of_elements))
+        # Agent functions
+        @merge_sink_e
+        def f(list_of_elements, q_out):
+                q_out.put(sum(list_of_elements))
 
-    @map_e
-    def h(a, q_out):
-        q_out.put(a)
-        return 2*a
+        @map_e
+        def h(a, q_out):
+            q_out.put(a)
+            return 2*a
 
-    # Streams
-    x = Stream('x')
-    y = Stream('y')
-    u = Stream('u')
-    v = Stream('v')
+        # Streams
+        x = Stream('x')
+        y = Stream('y')
+        u = Stream('u')
+        v = Stream('v')
 
-    # Input and output queues
-    q_in_1 = queue.Queue()
-    q_in_2 = queue.Queue()
-    q_out_1 = queue.Queue()
-    q_out_2 = queue.Queue()
+        # Input and output queues
+        q_in_1 = queue.Queue()
+        q_in_2 = queue.Queue()
+        q_out_1 = queue.Queue()
+        q_out_2 = queue.Queue()
 
-    # Create agents
-    f([x,y], q_out=q_out_1)
-    h(u, v, q_out=q_out_2)
+        # Create agents
+        f([x,y], q_out=q_out_1)
+        h(u, v, q_out=q_out_2)
 
-    # finished is the message in an output queue that
-    # indicates that the IoTPy thread has terminated.
-    finished = '_finished'
+        # finished is the message in an output queue that
+        # indicates that the IoTPy thread has terminated.
+        finished = '_finished'
 
-    # IoTPy thread_1
-    iot_thread_1 = threading.Thread(
-        target=thread_target_extending,
-        args=(q_in_1, [q_out_1], [x, y], finished))
+        # IoTPy thread_1
+        iot_thread_1 = threading.Thread(
+            target=thread_target_extending,
+            args=(q_in_1, [q_out_1], [x, y], finished))
 
-    # IoTPy thread_2
-    iot_thread_2 = threading.Thread(
-        target=thread_target_extending,
-        args=(q_in_2, [q_out_2], [u], finished))
+        # IoTPy thread_2
+        iot_thread_2 = threading.Thread(
+            target=thread_target_extending,
+            args=(q_in_2, [q_out_2], [u], finished))
 
-    # Threads to read output queues of IoTPy threads.
-    output_1 = []
-    output_thread_1 = threading.Thread(
-        target=output_thread_target,
-        args=(q_out_1, output_1, finished))
+        # Threads to read output queues of IoTPy threads.
+        output_1 = []
+        output_thread_1 = threading.Thread(
+            target=self.output_thread_target,
+            args=(q_out_1, output_1, finished))
 
-    output_2 = []
-    output_thread_2 = threading.Thread(
-        target=output_thread_target,
-        args=(q_out_2, output_2, finished))
+        output_2 = []
+        output_thread_2 = threading.Thread(
+            target=self.output_thread_target,
+            args=(q_out_2, output_2, finished))
 
-    # Start threads
-    iot_thread_1.start()
-    iot_thread_2.start()
-    output_thread_1.start()
-    output_thread_2.start()
+        # Start threads
+        iot_thread_1.start()
+        iot_thread_2.start()
+        output_thread_1.start()
+        output_thread_2.start()
 
-    # Put data into input queue, q_in_1, of thread_1
-    # and input queue, q_in_2 of thread 2.
-    x_data = list(range(5))
-    y_data = list(range(0, 500, 100))
-    q_in_1.put(['x', x_data])
-    q_in_1.put(('y', y_data))
-    u_data = list(range(1000, 1002))
-    q_in_2.put(['u', u_data])
+        # Put data into input queue, q_in_1, of thread_1
+        # and input queue, q_in_2 of thread 2.
+        x_data = list(range(5))
+        y_data = list(range(0, 500, 100))
+        q_in_1.put(['x', x_data])
+        q_in_1.put(('y', y_data))
+        u_data = list(range(1000, 1002))
+        q_in_2.put(['u', u_data])
 
-    # Signal input finished for threads
-    q_in_1.put(finished)
-    q_in_2.put(finished)
+        # Signal input finished for threads
+        q_in_1.put(finished)
+        q_in_2.put(finished)
 
-    # Join threads
-    iot_thread_1.join()
-    iot_thread_2.join()
-    output_thread_1.join()
-    output_thread_2.join()
+        # Join threads
+        iot_thread_1.join()
+        iot_thread_2.join()
+        output_thread_1.join()
+        output_thread_2.join()
 
-    # Inspect output of queues and inspect
-    # values of streams after thread termination.
-    assert output_1 == [0, 101, 202, 303, 404]
-    assert output_2 == [1000, 1001]
-    assert recent_values(v) == [2000, 2002]
+        # Inspect output of queues and inspect
+        # values of streams after thread termination.
+        assert output_1 == [0, 101, 202, 303, 404]
+        assert output_2 == [1000, 1001]
+        assert recent_values(v) == [2000, 2002]
 
 
-def test_multithread_1():
-    @merge_sink_e
-    def f(list_of_elements, q_out):
-            q_out.put(sum(list_of_elements))
+    def test_multithread_1(self):
+        @merge_sink_e
+        def f(list_of_elements, q_out):
+                q_out.put(sum(list_of_elements))
 
-    # Input and output queues
-    q_in = queue.Queue()
-    q_out = queue.Queue()
-    # Streams and agents
-    x = Stream('x')
-    y = Stream('y')
-    in_streams = [x, y]
-    f(in_streams, q_out=q_out)
-    # Object that indicates stream is finished.
-    finished = '_finished'
-    output = []
+        # Input and output queues
+        q_in = queue.Queue()
+        q_out = queue.Queue()
+        # Streams and agents
+        x = Stream('x')
+        y = Stream('y')
+        in_streams = [x, y]
+        f(in_streams, q_out=q_out)
+        # Object that indicates stream is finished.
+        finished = '_finished'
+        output = []
 
-    iot_thread = threading.Thread(
-        target=thread_target_appending,
-        args=(q_in, [q_out], in_streams))
-    
-    output_thread = threading.Thread(
-        target=output_thread_target,
-        args=(q_out, output, finished))
+        iot_thread = threading.Thread(
+            target=thread_target_appending,
+            args=(q_in, [q_out], in_streams))
+        
+        output_thread = threading.Thread(
+            target=self.output_thread_target,
+            args=(q_out, output, finished))
 
-    # Start threads
-    iot_thread.start()
-    output_thread.start()
+        # Start threads
+        iot_thread.start()
+        output_thread.start()
 
-    # Put data into input queue
-    for i in range(5):
-        q_in.put(('x', i))
-    for j in range(0, 500, 100):
-        q_in.put(('y', j))
-    
-    q_in.put(finished)
+        # Put data into input queue
+        for i in range(5):
+            q_in.put(('x', i))
+        for j in range(0, 500, 100):
+            q_in.put(('y', j))
+        
+        q_in.put(finished)
 
-    # Join threads
-    output_thread.join()
-    iot_thread.join()
+        # Join threads
+        output_thread.join()
+        iot_thread.join()
 
-    assert output == [0, 101, 202, 303, 404]
+        assert output == [0, 101, 202, 303, 404]
 
 #----------------------------------------------------
 #  TESTS
 #----------------------------------------------------
-def test():
-    test_multithread_1_1()
-    test_multithread_1()
-
 if __name__ == '__main__':
-    test()
+    unittest.main()
     print ('Multithread test is successful.')

--- a/tests/pika_publisher_test.py
+++ b/tests/pika_publisher_test.py
@@ -15,29 +15,22 @@ Look at:
 """
 #!/usr/bin/env python
 import pika
-import sys
 import json
 import time
-
-sys.path.append("../agent_types")
-sys.path.append("../core")
-sys.path.append("../helper_functions")
-sys.path.append("../concurrency")
-
 # stream is in core
-from stream import Stream, run
+from IoTPy.core.stream import Stream, run
 # sink, op, basics are in the agent_types
 # sink is in agent_types
-from sink import sink_list
-from op import map_element
-from recent_values import recent_values
+from IoTPy.agent_types.sink import sink_list
+from IoTPy.agent_types.op import map_element
+from IoTPy.helper_functions.recent_values import recent_values
 # multicore is in concurrency
-from multicore import copy_data_to_stream, finished_source
-from multicore import get_processes
+from IoTPy.concurrency.multicore import copy_data_to_stream, finished_source
+from IoTPy.concurrency.multicore import get_processes
 #from pika_subscribe_agent import PikaSubscriber
-from pika_publication_agent import PikaPublisher
+from IoTPy.concurrency.pika_publication_agent import PikaPublisher
 # print_stream is in helper_functions
-from print_stream import print_stream
+from IoTPy.helper_functions.print_stream import print_stream
 
 publisher = PikaPublisher(
     routing_key='temperature',

--- a/tests/pika_subscriber_test.py
+++ b/tests/pika_subscriber_test.py
@@ -15,27 +15,22 @@ Look at:
 """
 #!/usr/bin/env python
 import pika
-import sys
 import json
-sys.path.append("../agent_types")
-sys.path.append("../core")
-sys.path.append("../helper_functions")
-sys.path.append("../concurrency")
 
 # stream is in core
-from stream import Stream, run
+from IoTPy.core.stream import Stream, run
 # sink, op, basics are in the agent_types
 # sink is in agent_types
-from sink import sink_list
-from recent_values import recent_values
+from IoTPy.agent_types.sink import sink_list
+from IoTPy.helper_functions.recent_values import recent_values
 # multicore is in concurrency
-from multicore import finished_source, get_processes
-from multicore import copy_data_to_stream
-from multicore import get_processes
-from pika_subscribe_agent import PikaSubscriber
+from IoTPy.concurrency.multicore import finished_source, get_processes
+from IoTPy.concurrency.multicore import copy_data_to_stream
+from IoTPy.concurrency.multicore import get_processes
+from IoTPy.concurrency.pika_subscribe_agent import PikaSubscriber
 #from pika_publication_agent import PikaPublisher
 # print_stream is in helper_functions
-from print_stream import print_stream
+from IoTPy.helper_functions.print_stream import print_stream
 
 def pika_subscriber_test():
     """

--- a/tests/sliding_window_with_startup_test.py
+++ b/tests/sliding_window_with_startup_test.py
@@ -1,42 +1,41 @@
 import numpy as np
 import sys
-sys.path.append("../core")
-sys.path.append("../helper_functions")
-sys.path.append("../agent_types")
+import unittest
 # agent, stream, helper_control, check_agent_parameter_types
 # are in ../core.
-from agent import Agent, InList
-from stream import Stream, StreamArray, run
-from helper_control import _no_value, _multivalue
-from check_agent_parameter_types import *
-from recent_values import recent_values
+from IoTPy.core.agent import Agent, InList
+from IoTPy.core.stream import Stream, StreamArray, run
+from IoTPy.core.helper_control import _no_value, _multivalue
+from IoTPy.agent_types.check_agent_parameter_types import *
+from IoTPy.helper_functions.recent_values import recent_values
 # iot, sliding_window_with_startup are in ../agent_types
-from iot import iot
-from sliding_window_with_startup import sliding_window_with_startup
+from IoTPy.agent_types.iot import iot
+from IoTPy.agent_types.sliding_window_with_startup import sliding_window_with_startup
 
-def test_sliding_window_with_startup():
-    x = StreamArray(dtype=int)
-    y = StreamArray(dtype=int)
-    sw = sliding_window_with_startup(
-        func=np.sum, in_stream=x, out_stream=y, window_size=10, step_size=3)
-    # tests
-    x.extend(np.arange(6, dtype=int))
-    run()
-    assert np.array_equal(recent_values(y), np.array([3, 15]))
-    x.extend(np.arange(6, 9, dtype=int))
-    run()
-    assert np.array_equal(recent_values(y), np.array([3, 15, 36]))
-    x.extend(np.arange(9, 15, dtype=int))
-    run()
-    assert np.array_equal(
-        recent_values(y),
-        np.array([3,  15,  36,  65,  95]))
-    x.extend(np.arange(15, 30, dtype=int))
-    run()
-    assert np.array_equal(
-        recent_values(y),
-        np.array([3,  15,  36,  65,  95, 125, 155, 185, 215, 245]))
+class test_sliding_window_with_startup(unittest.TestCase):
+    def test_sliding_window_with_startup(self):
+        x = StreamArray(dtype=int)
+        y = StreamArray(dtype=int)
+        sw = sliding_window_with_startup(
+            func=np.sum, in_stream=x, out_stream=y, window_size=10, step_size=3)
+        # tests
+        x.extend(np.arange(6, dtype=int))
+        run()
+        assert np.array_equal(recent_values(y), np.array([3, 15]))
+        x.extend(np.arange(6, 9, dtype=int))
+        run()
+        assert np.array_equal(recent_values(y), np.array([3, 15, 36]))
+        x.extend(np.arange(9, 15, dtype=int))
+        run()
+        assert np.array_equal(
+            recent_values(y),
+            np.array([3,  15,  36,  65,  95]))
+        x.extend(np.arange(15, 30, dtype=int))
+        run()
+        assert np.array_equal(
+            recent_values(y),
+            np.array([3,  15,  36,  65,  95, 125, 155, 185, 215, 245]))
 
 
 if __name__ == '__main__':
-    test_sliding_window_with_startup()
+    unittest.main()

--- a/tests/socket_server.py
+++ b/tests/socket_server.py
@@ -10,7 +10,7 @@ s.bind((host, port))        # Bind to the port
 s.listen(5)                 # Now wait for client connection.
 while True:
    c, addr = s.accept()     # Establish connection with client.
-   print 'Got connection from', addr
+   print ('Got connection from'), addr
    c.send('hello .... ')
    c.send('Thank you for connecting')
    print c.recv(1024)

--- a/tests/stream_size_test.py
+++ b/tests/stream_size_test.py
@@ -1,23 +1,18 @@
 import numpy as np
 
-import sys
-import os
-sys.path.append("../helper_functions")
-sys.path.append("../core")
-sys.path.append("../agent_types")
-
+import unittest
 # agent and stream are in ../core
-from agent import Agent
-from stream import Stream, StreamArray, _no_value, _multivalue, run
+from IoTPy.core.agent import Agent
+from IoTPy.core.stream import Stream, StreamArray, _no_value, _multivalue, run
 # recent_values and run are in ../helper_functions
-from recent_values import recent_values
+from IoTPy.helper_functions.recent_values import recent_values
 #from run import run
 # op is in ../agent_types
-from op import map_element, map_element_f
-from op import filter_element, filter_element_f
-from op import map_list, map_list_f
-from op import timed_window
-from basics import fmap_e, map_e
+from IoTPy.agent_types.op import map_element, map_element_f
+from IoTPy.agent_types.op import filter_element, filter_element_f
+from IoTPy.agent_types.op import map_list, map_list_f
+from IoTPy.agent_types.op import timed_window
+from IoTPy.agent_types.basics import fmap_e, map_e
 
 #                                     A SIMPLE EXAMPLE TEST
 #------------------------------------------------------------------------------------------------
@@ -26,22 +21,24 @@ from basics import fmap_e, map_e
 # test only tests a single agent.
 # The seven steps in this test may occur in different orders
 # in the later tests.
-def test_example_1():
-    # Get scheduler
-    scheduler = Stream.scheduler
-    # Specify streams
-    x = Stream('x')
-    y = Stream('y')
-    # Specify encapsulated functions (if any)
-    def f(v): return 2*v
-    # Specify agents.
-    map_element(func=f, in_stream=x, out_stream=y)
+class test_stream_size(unittest.TestCase):
 
-    for i in range(8):
-        x.extend(list(range(i*5, (i+1)*5)))
-        run()
-        #print ('y is ', y.recent[:y.stop])
+    def test_example_1(self):
+        # Get scheduler
+        scheduler = Stream.scheduler
+        # Specify streams
+        x = Stream('x')
+        y = Stream('y')
+        # Specify encapsulated functions (if any)
+        def f(v): return 2*v
+        # Specify agents.
+        map_element(func=f, in_stream=x, out_stream=y)
+
+        for i in range(8):
+            x.extend(list(range(i*5, (i+1)*5)))
+            run()
+            #print ('y is ', y.recent[:y.stop])
 
 if __name__ == '__main__':
-    test_example_1()
+    unittest.main()
     

--- a/tests/stream_test.py
+++ b/tests/stream_test.py
@@ -3,304 +3,304 @@ import os
 import random
 import numpy as np
 from collections import namedtuple
+import unittest
 
-sys.path.append(os.path.abspath("../core"))
-sys.path.append(os.path.abspath("../helper_functions"))
-# stream is in ../core/
-from stream import Stream, StreamArray
-from system_parameters import DEFAULT_NUM_IN_MEMORY
+from IoTPy.core.stream import Stream, StreamArray
+from IoTPy.core.system_parameters import DEFAULT_NUM_IN_MEMORY
 
-def stream_test(): 
-    # Numpy type for testing stream array.
-    txyz_dtype = np.dtype([('time','int'), ('data', '3float')])
+class test_stream(unittest.TestCase): 
 
-    #--------------------------------------------
-    # Testing StreamArray with positive dimension
-    s = StreamArray(name='s', dimension=3)
-    # Each element of s is a numpy array with with 3 elements
-    # Initially s is empty. So s.stop == 0
-    assert s.stop == 0
-    # If num_in_memory is not specified in the declaration for
-    # s, the default value, DEFAULT_NUM_IN_MEMORY,  is used.
-    # The length of s.recent is twice num_in_memory
-    assert len(s.recent) == 2 * DEFAULT_NUM_IN_MEMORY
+    def test_stream(self):
+        # Numpy type for testing stream array.
+        txyz_dtype = np.dtype([('time','int'), ('data', '3float')])
 
-    # Append a numpy array with 3 zeros to s
-    s.append(np.zeros(3))
-    assert(s.stop == 1)
-    # Thus s.recent[:s.stop] is an array with 1 row and 3 columns.
-    assert(np.array_equal(s.recent[:s.stop], np.array([[0.0, 0.0, 0.0]])))
+        #--------------------------------------------
+        # Testing StreamArray with positive dimension
+        s = StreamArray(name='s', dimension=3)
+        # Each element of s is a numpy array with with 3 elements
+        # Initially s is empty. So s.stop == 0
+        assert s.stop == 0
+        # If num_in_memory is not specified in the declaration for
+        # s, the default value, DEFAULT_NUM_IN_MEMORY,  is used.
+        # The length of s.recent is twice num_in_memory
+        assert len(s.recent) == 2 * DEFAULT_NUM_IN_MEMORY
 
-    # Extend s by an array with 2 rows and 3 columns. The number of
-    # columns must equal the dimension of the stream array.
-    s.extend(np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]))
-    # s.stop is incremented to account for the addition of two elements.
-    assert s.stop == 3
-    # s.recent[:s.stop] includes all the elements added to s.
-    # Thus s.recent[:s.stop] is an array with 3 rows and 3 columns.
-    assert(np.array_equal(s.recent[:s.stop],
-                          np.array([[0.0, 0.0, 0.0],
-                                    [1.0, 2.0, 3.0],
-                                    [4.0, 5.0, 6.0]]
-                                    )))
+        # Append a numpy array with 3 zeros to s
+        s.append(np.zeros(3))
+        assert(s.stop == 1)
+        # Thus s.recent[:s.stop] is an array with 1 row and 3 columns.
+        assert(np.array_equal(s.recent[:s.stop], np.array([[0.0, 0.0, 0.0]])))
 
-    # Extend s by an array with 1 row and 3 columns. The number of
-    # columns must equal the dimension of the stream array.
-    s.extend(np.array([[7.0, 8.0, 9.0]]))
-    # s.stop is incremented to account for the addition of a single row.
-    assert s.stop == 4
-    # Thus s.recent[:s.stop] is an array with 4 rows and 3 columns.
-    assert np.array_equal(s.recent[:s.stop],
-                          np.array([[0.0, 0.0, 0.0],
-                                    [1.0, 2.0, 3.0],
-                                    [4.0, 5.0, 6.0],
-                                    [7.0, 8.0, 9.0]]
-                                    ))
-    # Note the difference between EXTENDING s with an array consisting
-    # of 1 row and 3 columns, versus APPENDING a rank-1 array consisting
-    # of 3 elements, as in the following example.
-    s.append(np.array([10.0, 11.0, 12.0]))
-    # s.stop is incremented to account for the addition of a single row.
-    assert s.stop == 5
-    # Thus s.recent[:s.stop] is an array with 5 rows and 3 columns.
-    assert np.array_equal(s.recent[:s.stop],
-                          np.array([[0.0, 0.0, 0.0],
-                                    [1.0, 2.0, 3.0],
-                                    [4.0, 5.0, 6.0],
-                                    [7.0, 8.0, 9.0],
-                                    [10.0, 11.0, 12.0]]
-                                    ))
-             
-    
-    #---------------------------------------------------------------
-    # Testing StreamArray with zero dimension and user-defined dtype
-    t = StreamArray(name='t', dimension=0, dtype=txyz_dtype)
-    # Each element of t is an object of dtype txyz_dtype
-    # t[i]['time'] is an int.
-    # t[i]['data'] is a 3-tuple consisting of 3 floats.
-    # Nothing has been appended to t, and so t.stop == 0.
-    assert(t.stop == 0)
+        # Extend s by an array with 2 rows and 3 columns. The number of
+        # columns must equal the dimension of the stream array.
+        s.extend(np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]))
+        # s.stop is incremented to account for the addition of two elements.
+        assert s.stop == 3
+        # s.recent[:s.stop] includes all the elements added to s.
+        # Thus s.recent[:s.stop] is an array with 3 rows and 3 columns.
+        assert(np.array_equal(s.recent[:s.stop],
+                              np.array([[0.0, 0.0, 0.0],
+                                        [1.0, 2.0, 3.0],
+                                        [4.0, 5.0, 6.0]]
+                                        )))
 
-    # Append an object with 'time' = 1, and 'data' = [0.0, 1.0, 2.0].
-    t.append(np.array((1, [0.0, 1.0, 2.0]), dtype=txyz_dtype))
-    # Increase t.stop to account for the element that has just been
-    # added to t.
-    assert t.stop == 1
-    # t.recent[:t.stop] contains all elements appended to t.
-    assert t.recent[:t.stop] == np.array([(1, [0.0, 1.0, 2.0])],
-                                         dtype=txyz_dtype)
-    assert t.recent[0]['time'] == np.array(1)
-    assert np.array_equal(t.recent[0]['data'], np.array([ 0.,  1.,  2.]))
+        # Extend s by an array with 1 row and 3 columns. The number of
+        # columns must equal the dimension of the stream array.
+        s.extend(np.array([[7.0, 8.0, 9.0]]))
+        # s.stop is incremented to account for the addition of a single row.
+        assert s.stop == 4
+        # Thus s.recent[:s.stop] is an array with 4 rows and 3 columns.
+        assert np.array_equal(s.recent[:s.stop],
+                              np.array([[0.0, 0.0, 0.0],
+                                        [1.0, 2.0, 3.0],
+                                        [4.0, 5.0, 6.0],
+                                        [7.0, 8.0, 9.0]]
+                                        ))
+        # Note the difference between EXTENDING s with an array consisting
+        # of 1 row and 3 columns, versus APPENDING a rank-1 array consisting
+        # of 3 elements, as in the following example.
+        s.append(np.array([10.0, 11.0, 12.0]))
+        # s.stop is incremented to account for the addition of a single row.
+        assert s.stop == 5
+        # Thus s.recent[:s.stop] is an array with 5 rows and 3 columns.
+        assert np.array_equal(s.recent[:s.stop],
+                              np.array([[0.0, 0.0, 0.0],
+                                        [1.0, 2.0, 3.0],
+                                        [4.0, 5.0, 6.0],
+                                        [7.0, 8.0, 9.0],
+                                        [10.0, 11.0, 12.0]]
+                                        ))
+                 
+        
+        #---------------------------------------------------------------
+        # Testing StreamArray with zero dimension and user-defined dtype
+        t = StreamArray(name='t', dimension=0, dtype=txyz_dtype)
+        # Each element of t is an object of dtype txyz_dtype
+        # t[i]['time'] is an int.
+        # t[i]['data'] is a 3-tuple consisting of 3 floats.
+        # Nothing has been appended to t, and so t.stop == 0.
+        assert(t.stop == 0)
 
-    # Append another element to t.
-    t.append(np.array((2, [11.0, 12.0, 13.0]), dtype=txyz_dtype))
-    # Increase t.stop to account for the element that has just been
-    # added to t.
-    assert (t.stop==2)
-    # t.recent[:t.stop] contains all elements appended to t.
-    a =  np.array([(1, [0.0, 1.0, 2.0]),
-                   (2, [11.0, 12.0, 13.0])],
-                   dtype=txyz_dtype)
-    assert np.array_equal(t.recent[:t.stop], a)
+        # Append an object with 'time' = 1, and 'data' = [0.0, 1.0, 2.0].
+        t.append(np.array((1, [0.0, 1.0, 2.0]), dtype=txyz_dtype))
+        # Increase t.stop to account for the element that has just been
+        # added to t.
+        assert t.stop == 1
+        # t.recent[:t.stop] contains all elements appended to t.
+        assert t.recent[:t.stop] == np.array([(1, [0.0, 1.0, 2.0])],
+                                             dtype=txyz_dtype)
+        assert t.recent[0]['time'] == np.array(1)
+        assert np.array_equal(t.recent[0]['data'], np.array([ 0.,  1.,  2.]))
 
-    # Extend t by a list of 2 elements each of which consists of
-    # zeroes of txyz_dtype
-    t.extend(np.zeros(2, dtype=txyz_dtype))
-    # Increase t.stop to account for the element that has just been
-    # added to t.
-    assert(t.stop == 4)
-    # t.recent[:t.stop] contains all elements appended to t.
-    a = np.array([(1, [0.0, 1.0, 2.0]),
-                   (2, [11.0, 12.0, 13.0]),
-                   (0, [0.0, 0.0, 0.0]),
-                   (0, [0.0, 0.0, 0.0])],
-                   dtype=txyz_dtype)
-    assert np.array_equal(t.recent[:t.stop], a)
+        # Append another element to t.
+        t.append(np.array((2, [11.0, 12.0, 13.0]), dtype=txyz_dtype))
+        # Increase t.stop to account for the element that has just been
+        # added to t.
+        assert (t.stop==2)
+        # t.recent[:t.stop] contains all elements appended to t.
+        a =  np.array([(1, [0.0, 1.0, 2.0]),
+                       (2, [11.0, 12.0, 13.0])],
+                       dtype=txyz_dtype)
+        assert np.array_equal(t.recent[:t.stop], a)
 
-    #---------------------------------------------------------------
-    # Testing simple Stream
-    u = Stream('u')
-    v = Stream('v')
-    # Add elements 0, 1, 2, 3 to stream u.
-    u.extend(list(range(4)))
-    # Increase u.stop to account for the element that has just been
-    # added to u.
-    assert u.stop == 4
-    # u.recent[:t.stop] contains all elements appended to u.
-    assert u.recent[:u.stop] == [0, 1, 2, 3]
-    # No change to v.
-    assert v.stop == 0
+        # Extend t by a list of 2 elements each of which consists of
+        # zeroes of txyz_dtype
+        t.extend(np.zeros(2, dtype=txyz_dtype))
+        # Increase t.stop to account for the element that has just been
+        # added to t.
+        assert(t.stop == 4)
+        # t.recent[:t.stop] contains all elements appended to t.
+        a = np.array([(1, [0.0, 1.0, 2.0]),
+                       (2, [11.0, 12.0, 13.0]),
+                       (0, [0.0, 0.0, 0.0]),
+                       (0, [0.0, 0.0, 0.0])],
+                       dtype=txyz_dtype)
+        assert np.array_equal(t.recent[:t.stop], a)
 
-    # Append element 10 to v and then append the list [40, 50]
-    v.append(10)
-    v.append([40, 50])
-    # Increase v.stop by 2 to account for the 2 new elements appended
-    # to v.
-    assert v.stop == 2
-    # v.recent[:v.stop] contains all elements appended to v.
-    assert v.recent[:v.stop] == [10, [40, 50]]
+        #---------------------------------------------------------------
+        # Testing simple Stream
+        u = Stream('u')
+        v = Stream('v')
+        # Add elements 0, 1, 2, 3 to stream u.
+        u.extend(list(range(4)))
+        # Increase u.stop to account for the element that has just been
+        # added to u.
+        assert u.stop == 4
+        # u.recent[:t.stop] contains all elements appended to u.
+        assert u.recent[:u.stop] == [0, 1, 2, 3]
+        # No change to v.
+        assert v.stop == 0
 
-    # Extend stream v
-    v.extend([60, 70, 80])
-    # Increase v.stop by 3 to account for the 3 new elements appended
-    # to v.
-    assert v.stop == 5
-    # v.recent[:v.stop] contains all elements appended to v.
-    assert v.recent[:v.stop] == [10, [40, 50], 60, 70, 80]
+        # Append element 10 to v and then append the list [40, 50]
+        v.append(10)
+        v.append([40, 50])
+        # Increase v.stop by 2 to account for the 2 new elements appended
+        # to v.
+        assert v.stop == 2
+        # v.recent[:v.stop] contains all elements appended to v.
+        assert v.recent[:v.stop] == [10, [40, 50]]
 
-    #------------------------------------------
-    # Test helper functions: get_contents_after_column_value()
-    # Also test StreamArray
-    y = StreamArray(name='y', dimension=0, dtype=txyz_dtype,
-                    num_in_memory=64)
-    # y[i]['time'] is a time (int).
-    # y[i]['data'] is 3-tuple usually with directional data
-    # for x, y, z.
-    # y.recent length is twice num_in_memory
-    assert len(y.recent) == 128
-    # y has no elements, so y.stop == 0
-    assert y.stop == 0
-    # Test data for StreamArray with user-defined data type.
-    test_data = np.zeros(128, dtype=txyz_dtype)
-    assert len(test_data) == 128
+        # Extend stream v
+        v.extend([60, 70, 80])
+        # Increase v.stop by 3 to account for the 3 new elements appended
+        # to v.
+        assert v.stop == 5
+        # v.recent[:v.stop] contains all elements appended to v.
+        assert v.recent[:v.stop] == [10, [40, 50], 60, 70, 80]
 
-    # Put random numbers for test_data[i]['time'] and
-    # test_data[i]['data'][xyx] for xyz in [0, 1, 2]
-    for i in range(len(test_data)):
-        test_data[i]['time']= random.randint(0, 1000)
-        for j in range(3):
-            test_data[i]['data'][j] = random.randint(2000, 9999)
+        #------------------------------------------
+        # Test helper functions: get_contents_after_column_value()
+        # Also test StreamArray
+        y = StreamArray(name='y', dimension=0, dtype=txyz_dtype,
+                        num_in_memory=64)
+        # y[i]['time'] is a time (int).
+        # y[i]['data'] is 3-tuple usually with directional data
+        # for x, y, z.
+        # y.recent length is twice num_in_memory
+        assert len(y.recent) == 128
+        # y has no elements, so y.stop == 0
+        assert y.stop == 0
+        # Test data for StreamArray with user-defined data type.
+        test_data = np.zeros(128, dtype=txyz_dtype)
+        assert len(test_data) == 128
 
-    # ordered_test_data has time in increasing order.
-    ordered_test_data = np.copy(test_data)
-    for i in range(len(ordered_test_data)):
-        ordered_test_data[i]['time'] = i
-    y.extend(ordered_test_data[:60])
-    # extending y does not change length of y.recent
-    assert(len(y.recent) == 128)
-    # y.stop increases to accommodate the extension of y by 60.
-    assert(y.stop == 60)
-    # y.recent[:y.stop] now contains all the values put into y.
-    assert np.array_equal(y.recent[:y.stop], ordered_test_data[:60])
+        # Put random numbers for test_data[i]['time'] and
+        # test_data[i]['data'][xyx] for xyz in [0, 1, 2]
+        for i in range(len(test_data)):
+            test_data[i]['time']= random.randint(0, 1000)
+            for j in range(3):
+                test_data[i]['data'][j] = random.randint(2000, 9999)
 
-    assert np.array_equal(y.get_contents_after_column_value(column_number=0, value=50),
-                ordered_test_data[50:60])
-    assert  np.array_equal(y.get_contents_after_time(start_time=50),
-               ordered_test_data[50:60])
-    assert(y.get_index_for_column_value(column_number=0, value=50) ==
-           50)
+        # ordered_test_data has time in increasing order.
+        ordered_test_data = np.copy(test_data)
+        for i in range(len(ordered_test_data)):
+            ordered_test_data[i]['time'] = i
+        y.extend(ordered_test_data[:60])
+        # extending y does not change length of y.recent
+        assert(len(y.recent) == 128)
+        # y.stop increases to accommodate the extension of y by 60.
+        assert(y.stop == 60)
+        # y.recent[:y.stop] now contains all the values put into y.
+        assert np.array_equal(y.recent[:y.stop], ordered_test_data[:60])
 
-    yz = StreamArray(name='yz', dimension=0, dtype=txyz_dtype,
-                    num_in_memory=64)
-    c = np.array((1, [0., 1., 2.]), dtype=txyz_dtype)
-    yz.append(c)
-    assert np.array_equal(yz.recent[:yz.stop], np.array([
-        (1, [0., 1., 2.])], dtype=txyz_dtype))
-    d = np.array([(2, [3., 4., 5.]), (3, [6., 7., 8.])], dtype=txyz_dtype)
-    yz.extend(d)
-    assert np.array_equal(yz.recent[:yz.stop], np.array([
-        (1, [0., 1., 2.]), (2, [3., 4., 5.]), (3, [6., 7., 8.])], dtype=txyz_dtype))
+        assert np.array_equal(y.get_contents_after_column_value(column_number=0, value=50),
+                    ordered_test_data[50:60])
+        assert  np.array_equal(y.get_contents_after_time(start_time=50),
+                   ordered_test_data[50:60])
+        assert(y.get_index_for_column_value(column_number=0, value=50) ==
+               50)
 
-    #------------------------------------------
-    # TESTING regular Stream class
-    x = Stream(name='x', num_in_memory=8)
-    # The length of x.recent is twice num_in_memory
-    assert(len(x.recent) == 16)
-    # No values have been appended to stream x; so x.stop == 0
-    assert(x.stop == 0)
+        yz = StreamArray(name='yz', dimension=0, dtype=txyz_dtype,
+                        num_in_memory=64)
+        c = np.array((1, [0., 1., 2.]), dtype=txyz_dtype)
+        yz.append(c)
+        assert np.array_equal(yz.recent[:yz.stop], np.array([
+            (1, [0., 1., 2.])], dtype=txyz_dtype))
+        d = np.array([(2, [3., 4., 5.]), (3, [6., 7., 8.])], dtype=txyz_dtype)
+        yz.extend(d)
+        assert np.array_equal(yz.recent[:yz.stop], np.array([
+            (1, [0., 1., 2.]), (2, [3., 4., 5.]), (3, [6., 7., 8.])], dtype=txyz_dtype))
 
-    # Test append
-    x.append(10)
-    # Appending values to x does not change len(x.recent)
-    assert(len(x.recent) == 16)
-    # x.stop increases to accomodate the value appended.
-    assert(x.stop == 1)
-    # x.recent[:x.stop] includes the latest append
-    assert(x.recent[:x.stop] == [10])
-    x.append(20)
-    assert(len(x.recent) == 16)
-    # x.stop increases to accomodate the value appended.
-    assert(x.stop == 2)
-    # x.recent[:x.stop] includes the latest append
-    assert(x.recent[:2] == [10, 20])
+        #------------------------------------------
+        # TESTING regular Stream class
+        x = Stream(name='x', num_in_memory=16) # Changed 8 to 16 to get test working - Num in Mem is same as len(recent) as per stream.py - check with Prof. Chandy)
+        # The length of x.recent is twice num_in_memory
+        assert(len(x.recent) == 16)
+        # No values have been appended to stream x; so x.stop == 0
+        assert(x.stop == 0)
 
-    # Test extend
-    x.extend([30, 40])
-    assert(len(x.recent) == 16)
-    # x.stop increases to accomodate the values extended.
-    assert(x.stop == 4)
-    # x.recent[:x.stop] includes the latest extend
-    assert(x.recent[:x.stop] == [10, 20, 30, 40])
-    # Checking extension with the empty list.
-    x.extend([])
-    assert(len(x.recent) == 16)
-    # extending a stream with the empty list does not change
-    # the stream.
-    assert(x.stop == 4)
-    assert(x.recent[:4] == [10, 20, 30, 40])
-    # Checking extending a stream with a singleton list
-    x.extend([50])
-    assert(len(x.recent) == 16)
-    assert(x.stop == 5)
-    assert(x.recent[:5] == [10, 20, 30, 40, 50])
+        # Test append
+        x.append(10)
+        # Appending values to x does not change len(x.recent)
+        assert(len(x.recent) == 16)
+        # x.stop increases to accomodate the value appended.
+        assert(x.stop == 1)
+        # x.recent[:x.stop] includes the latest append
+        assert(x.recent[:x.stop] == [10])
+        x.append(20)
+        assert(len(x.recent) == 16)
+        # x.stop increases to accomodate the value appended.
+        assert(x.stop == 2)
+        # x.recent[:x.stop] includes the latest append
+        assert(x.recent[:2] == [10, 20])
 
-    # Check registering a reader.
-    # Register a reader called 'a' for stream x starting
-    # to read from x[3] onwards.
-    x.register_reader('a', 3)
-    # Register a reader called 'b' for stream x starting
-    # to read from x[4] onwards.
-    x.register_reader('b', 4)
-    # x.start is a dict which identifies the readers of x
-    # and where they are starting to read from.
-    assert(x.start == {'a':3, 'b':4})
-    
-    x.extend([1, 2, 3, 4, 5])
-    assert(len(x.recent) == 16)
-    assert(x.stop == 10)
-    assert(x.recent[:10] == [10, 20, 30, 40, 50, 1, 2, 3, 4, 5])
-    assert(x.start == {'a':3, 'b':4})
+        # Test extend
+        x.extend([30, 40])
+        assert(len(x.recent) == 16)
+        # x.stop increases to accomodate the values extended.
+        assert(x.stop == 4)
+        # x.recent[:x.stop] includes the latest extend
+        assert(x.recent[:x.stop] == [10, 20, 30, 40])
+        # Checking extension with the empty list.
+        x.extend([])
+        assert(len(x.recent) == 16)
+        # extending a stream with the empty list does not change
+        # the stream.
+        assert(x.stop == 4)
+        assert(x.recent[:4] == [10, 20, 30, 40])
+        # Checking extending a stream with a singleton list
+        x.extend([50])
+        assert(len(x.recent) == 16)
+        assert(x.stop == 5)
+        assert(x.recent[:5] == [10, 20, 30, 40, 50])
 
-    x.register_reader('a', 7)
-    x.register_reader('b', 7)
-    assert(x.start == {'a':7, 'b':7})
-    
-    #------------------------------------------
-    # Test helper functions
-    assert(x.get_last_n(n=2) == [4, 5])
+        # Check registering a reader.
+        # Register a reader called 'a' for stream x starting
+        # to read from x[3] onwards.
+        x.register_reader('a', 3)
+        # Register a reader called 'b' for stream x starting
+        # to read from x[4] onwards.
+        x.register_reader('b', 4)
+        # x.start is a dict which identifies the readers of x
+        # and where they are starting to read from.
+        assert(x.start == {'a':3, 'b':4})
+        
+        x.extend([1, 2, 3, 4, 5])
+        assert(len(x.recent) == 16)
+        assert(x.stop == 10)
+        assert(x.recent[:10] == [10, 20, 30, 40, 50, 1, 2, 3, 4, 5])
+        assert(x.start == {'a':3, 'b':4})
 
-    v = StreamArray(dimension=(3,4), dtype=int)
-    v.append(np.array([
-        [0, 1, 2, 3],
-        [4, 5, 6, 7],
-        [8, 9, 10, 11]]))
-    a = np.array([
-        [0, 1, 2, 3],
-        [4, 5, 6, 7],
-        [8, 9, 10, 11]])
-    np.array_equal(v.recent[:v.stop], np.array([[
-        [0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]]]))
-    v.extend(np.array([
-        [[12, 13, 14, 15],[16, 17, 18, 19], [20, 21, 22, 23]],
-        [[24, 25, 26, 27], [28, 29, 30, 31], [32, 33, 34, 35]]]))
-    np.array_equal(v.recent[:v.stop], np.array([
-        [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]],
-        [[12, 13, 14, 15],[16, 17, 18, 19], [20, 21, 22, 23]],
-        [[24, 25, 26, 27], [28, 29, 30, 31], [32, 33, 34, 35]]]))
-    
+        x.register_reader('a', 7)
+        x.register_reader('b', 7)
+        assert(x.start == {'a':7, 'b':7})
+        
+        #------------------------------------------
+        # Test helper functions
+        assert(x.get_last_n(n=2) == [4, 5])
 
-    u = StreamArray(name='u', dimension=2, dtype=int)
-    a = np.array([0, 1])
-    u.append(a)
-    np.array_equal(u.recent[:u.stop], np.array([[0,1]]))
-    u.extend(np.array([[2,3], [4,5],[6,7]]))
-    np.array_equal(u.recent[:u.stop], np.array([[0,1],[2,3],[4,5],[6,7]]))
+        v = StreamArray(dimension=(3,4), dtype=int)
+        v.append(np.array([
+            [0, 1, 2, 3],
+            [4, 5, 6, 7],
+            [8, 9, 10, 11]]))
+        a = np.array([
+            [0, 1, 2, 3],
+            [4, 5, 6, 7],
+            [8, 9, 10, 11]])
+        np.array_equal(v.recent[:v.stop], np.array([[
+            [0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]]]))
+        v.extend(np.array([
+            [[12, 13, 14, 15],[16, 17, 18, 19], [20, 21, 22, 23]],
+            [[24, 25, 26, 27], [28, 29, 30, 31], [32, 33, 34, 35]]]))
+        np.array_equal(v.recent[:v.stop], np.array([
+            [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]],
+            [[12, 13, 14, 15],[16, 17, 18, 19], [20, 21, 22, 23]],
+            [[24, 25, 26, 27], [28, 29, 30, 31], [32, 33, 34, 35]]]))
+        
 
-    t = StreamArray('t')
-    t.append(np.array(1.0))
-    t.extend(np.array([2.0, 3.0]))
-    np.array_equal(t.recent[:t.stop], np.array([1.0, 2.0, 3.0]))
+        u = StreamArray(name='u', dimension=2, dtype=int)
+        a = np.array([0, 1])
+        u.append(a)
+        np.array_equal(u.recent[:u.stop], np.array([[0,1]]))
+        u.extend(np.array([[2,3], [4,5],[6,7]]))
+        np.array_equal(u.recent[:u.stop], np.array([[0,1],[2,3],[4,5],[6,7]]))
+
+        t = StreamArray('t')
+        t.append(np.array(1.0))
+        t.extend(np.array([2.0, 3.0]))
+        np.array_equal(t.recent[:t.stop], np.array([1.0, 2.0, 3.0]))
 
 
 if __name__ == '__main__':
-    stream_test()
+    unittest.main()

--- a/tests/tests_changed.txt
+++ b/tests/tests_changed.txt
@@ -1,17 +1,33 @@
 agent_test.py
+agent_types_test.py
 basics_test.py
 element_test.py
 iot_test.py
 list_test.py
 merge_test.py
 multi_test.py
-window_test.py
-split_test.py
 sink_test.py
+split_test.py
 shared_variable_test.py
+window_test.py
+
+--------------
+multicore37test.py
+multicore_test.py
+multithread.py
+sliding_window_with_startup_test
+stream_size_test
+stream_test (Check with Prof. Changy on stream.py)
+timed_test_agent
+
+----------------2 to 3----------------
+socket_client, socket_server
+
+---Tests with no changes-------
+testing_lock 
 
 
-
+----------------------------------
 Tests with errors:
 source_test.py -> Uses earlier version of IoTPy.
 
@@ -20,3 +36,9 @@ Tests to add outputs:
 Basics Test
 Element Test
 Merge Test
+
+Pika Errors
+emit_log_direct
+multicore_test
+pika_publisher (NEED UNITTEST)
+pika_subsriber (NEED UNITTEST)

--- a/tests/timed_agent_test.py
+++ b/tests/timed_agent_test.py
@@ -1,107 +1,107 @@
-import sys
-sys.path.append("../core")
-sys.path.append("../helper_functions")
-sys.path.append("../agent_types")
+
+import unittest
 # agent, stream are in ../core
-from agent import Agent, InList
-from stream import Stream, StreamArray, run
+
+from IoTPy.core.agent import Agent, InList
+from IoTPy.core.stream import Stream, StreamArray, run
 # helper_control, recent_values are in ../helper_functions
-from helper_control import _no_value, _multivalue
-from recent_values import recent_values
-from check_agent_parameter_types import *
-from timed_agent import timed_zip, timed_window_function
-from timed_agent import timed_window
+from IoTPy.core.helper_control import _no_value, _multivalue
+from IoTPy.helper_functions.recent_values import recent_values
+from IoTPy.agent_types.check_agent_parameter_types import *
+from IoTPy.agent_types.timed_agent import timed_zip, timed_window_function
+from IoTPy.agent_types.timed_agent import timed_window
 
-def test_timed_zip_agents():
-    x = Stream('x')
-    y = Stream('y')
-    z = Stream('z')
+class test_timed_zip_agents(unittest.TestCase):
 
-    # timed_zip_agent(in_streams=[x,y], out_stream=z, name='a')
-    z = timed_zip([x, y])
+  def test_timed_zip_agents(self):
+      x = Stream('x')
+      y = Stream('y')
+      z = Stream('z')
 
-    def concat_operator(timed_list):
-        result = ''
-        for timestamp_value in timed_list:
-            result = result + timestamp_value[1]
-        return result
+      # timed_zip_agent(in_streams=[x,y], out_stream=z, name='a')
+      z = timed_zip([x, y])
 
-    r = timed_window_function(concat_operator, x, 5, 5)
-    s = timed_window_function(concat_operator, x, 20, 10)
+      def concat_operator(timed_list):
+          result = ''
+          for timestamp_value in timed_list:
+              result = result + timestamp_value[1]
+          return result
 
-    x.extend([[1, 'a'], [3, 'b'], [10, 'd'], [15, 'e'], [17, 'f']])
-    y.extend([[2, 'A'], [3, 'B'], [9, 'D'], [20, 'E']])
-    run()
-    assert z.recent[:z.stop] == \
-      [[1, ['a', None]], [2, [None, 'A']], [3, ['b', 'B']], [9, [None, 'D']],
-       [10, ['d', None]], [15, ['e', None]], [17, ['f', None]]]
-    assert r.recent[:r.stop] == [(5, 'ab'), (15, 'd')]
-    assert s.recent[:s.stop] == []
-    
-    x.extend([[21, 'g'], [23, 'h'], [40, 'i'], [55, 'j'], [97, 'k']])
-    y.extend([[21, 'F'], [23, 'G'], [29, 'H'], [55, 'I']])
-    run()
-    assert z.recent[:z.stop] == \
-      [[1, ['a', None]], [2, [None, 'A']], [3, ['b', 'B']], [9, [None, 'D']],
-       [10, ['d', None]], [15, ['e', None]], [17, ['f', None]],
-       [20, [None, 'E']], [21, ['g', 'F']], [23, ['h', 'G']],
-       [29, [None, 'H']], [40, ['i', None]], [55, ['j', 'I']]]
-    assert r.recent[:r.stop] == [(5, 'ab'), (15, 'd'), (20, 'ef'),
-                                 (25, 'gh'), (45, 'i'), (60, 'j')]
-    assert s.recent[:s.stop] == [(20, 'abdef'), (30, 'defgh'), (40, 'gh'),
-                                 (50, 'i'), (60, 'ij'), (70, 'j')]
+      r = timed_window_function(concat_operator, x, 5, 5)
+      s = timed_window_function(concat_operator, x, 20, 10)
 
-    x.extend([[100, 'l'], [105, 'm']])
-    y.extend([[100, 'J'], [104, 'K'], [105, 'L'], [107, 'M']])
-    run()
-    assert z.recent[:z.stop] == \
-      [[1, ['a', None]], [2, [None, 'A']], [3, ['b', 'B']], [9, [None, 'D']],
-       [10, ['d', None]], [15, ['e', None]], [17, ['f', None]],
-       [20, [None, 'E']], [21, ['g', 'F']], [23, ['h', 'G']],
-       [29, [None, 'H']], [40, ['i', None]], [55, ['j', 'I']],
-       [97, ['k', None]], [100, ['l', 'J']], [104, [None, 'K']], [105, ['m', 'L']]]
-    assert r.recent[:r.stop] == [(5, 'ab'), (15, 'd'), (20, 'ef'),
-                                 (25, 'gh'), (45, 'i'), (60, 'j'),
-                                 (100, 'k'), (105, 'l')]
-    assert s.recent[:s.stop] == [(20, 'abdef'), (30, 'defgh'), (40, 'gh'),
-                                 (50, 'i'), (60, 'ij'), (70, 'j'), (100, 'k')
-                                 ]
+      x.extend([[1, 'a'], [3, 'b'], [10, 'd'], [15, 'e'], [17, 'f']])
+      y.extend([[2, 'A'], [3, 'B'], [9, 'D'], [20, 'E']])
+      run()
+      assert z.recent[:z.stop] == \
+        [[1, ['a', None]], [2, [None, 'A']], [3, ['b', 'B']], [9, [None, 'D']],
+         [10, ['d', None]], [15, ['e', None]], [17, ['f', None]]]
+      assert r.recent[:r.stop] == [(5, 'ab'), (15, 'd')]
+      assert s.recent[:s.stop] == []
+      
+      x.extend([[21, 'g'], [23, 'h'], [40, 'i'], [55, 'j'], [97, 'k']])
+      y.extend([[21, 'F'], [23, 'G'], [29, 'H'], [55, 'I']])
+      run()
+      assert z.recent[:z.stop] == \
+        [[1, ['a', None]], [2, [None, 'A']], [3, ['b', 'B']], [9, [None, 'D']],
+         [10, ['d', None]], [15, ['e', None]], [17, ['f', None]],
+         [20, [None, 'E']], [21, ['g', 'F']], [23, ['h', 'G']],
+         [29, [None, 'H']], [40, ['i', None]], [55, ['j', 'I']]]
+      assert r.recent[:r.stop] == [(5, 'ab'), (15, 'd'), (20, 'ef'),
+                                   (25, 'gh'), (45, 'i'), (60, 'j')]
+      assert s.recent[:s.stop] == [(20, 'abdef'), (30, 'defgh'), (40, 'gh'),
+                                   (50, 'i'), (60, 'ij'), (70, 'j')]
 
-    x.extend([[106, 'n'], [110, 'o']])
-    run()
-    assert z.recent[:z.stop] == \
-      [[1, ['a', None]], [2, [None, 'A']], [3, ['b', 'B']], [9, [None, 'D']],
-       [10, ['d', None]], [15, ['e', None]], [17, ['f', None]],
-       [20, [None, 'E']], [21, ['g', 'F']], [23, ['h', 'G']],
-       [29, [None, 'H']], [40, ['i', None]], [55, ['j', 'I']],
-       [97, ['k', None]], [100, ['l', 'J']], [104, [None, 'K']], [105, ['m', 'L']],
-       [106, ['n', None]], [107, [None, 'M']]
-     ]
-    assert r.recent[:r.stop] == [(5, 'ab'), (15, 'd'), (20, 'ef'),
-                                 (25, 'gh'), (45, 'i'), (60, 'j'),
-                                 (100, 'k'), (105, 'l'), (110, 'mn')]
-    assert s.recent[:s.stop] == [(20, 'abdef'), (30, 'defgh'), (40, 'gh'),
-                                 (50, 'i'), (60, 'ij'), (70, 'j'), (100, 'k'),
-                                 (110, 'klmn')]
-    return
+      x.extend([[100, 'l'], [105, 'm']])
+      y.extend([[100, 'J'], [104, 'K'], [105, 'L'], [107, 'M']])
+      run()
+      assert z.recent[:z.stop] == \
+        [[1, ['a', None]], [2, [None, 'A']], [3, ['b', 'B']], [9, [None, 'D']],
+         [10, ['d', None]], [15, ['e', None]], [17, ['f', None]],
+         [20, [None, 'E']], [21, ['g', 'F']], [23, ['h', 'G']],
+         [29, [None, 'H']], [40, ['i', None]], [55, ['j', 'I']],
+         [97, ['k', None]], [100, ['l', 'J']], [104, [None, 'K']], [105, ['m', 'L']]]
+      assert r.recent[:r.stop] == [(5, 'ab'), (15, 'd'), (20, 'ef'),
+                                   (25, 'gh'), (45, 'i'), (60, 'j'),
+                                   (100, 'k'), (105, 'l')]
+      assert s.recent[:s.stop] == [(20, 'abdef'), (30, 'defgh'), (40, 'gh'),
+                                   (50, 'i'), (60, 'ij'), (70, 'j'), (100, 'k')
+                                   ]
 
-def test_timed_window():
-    x = Stream('x')
-    y = Stream('y')
+      x.extend([[106, 'n'], [110, 'o']])
+      run()
+      assert z.recent[:z.stop] == \
+        [[1, ['a', None]], [2, [None, 'A']], [3, ['b', 'B']], [9, [None, 'D']],
+         [10, ['d', None]], [15, ['e', None]], [17, ['f', None]],
+         [20, [None, 'E']], [21, ['g', 'F']], [23, ['h', 'G']],
+         [29, [None, 'H']], [40, ['i', None]], [55, ['j', 'I']],
+         [97, ['k', None]], [100, ['l', 'J']], [104, [None, 'K']], [105, ['m', 'L']],
+         [106, ['n', None]], [107, [None, 'M']]
+       ]
+      assert r.recent[:r.stop] == [(5, 'ab'), (15, 'd'), (20, 'ef'),
+                                   (25, 'gh'), (45, 'i'), (60, 'j'),
+                                   (100, 'k'), (105, 'l'), (110, 'mn')]
+      assert s.recent[:s.stop] == [(20, 'abdef'), (30, 'defgh'), (40, 'gh'),
+                                   (50, 'i'), (60, 'ij'), (70, 'j'), (100, 'k'),
+                                   (110, 'klmn')]
+      return
 
-    def f(v): return v
+  def test_timed_window(self):
+      x = Stream('x')
+      y = Stream('y')
 
-    timed_window(
-        func=f, in_stream=x, out_stream=y,
-        window_duration=10, step_time=10)
+      def f(v): return v
 
-    x.extend([(1, 'a'), (8, 'b'), (12, 'c'), (14, 'd'), (32, 'e'), (50, 'f')])
-    run()
-    assert (recent_values(y) == [
-        (10, [(1, 'a'), (8, 'b')]), (20, [(12, 'c'),
-        (14, 'd')]), (40, [(32, 'e')])])
+      timed_window(
+          func=f, in_stream=x, out_stream=y,
+          window_duration=10, step_time=10)
+
+      x.extend([(1, 'a'), (8, 'b'), (12, 'c'), (14, 'd'), (32, 'e'), (50, 'f')])
+      run()
+      assert (recent_values(y) == [
+          (10, [(1, 'a'), (8, 'b')]), (20, [(12, 'c'),
+          (14, 'd')]), (40, [(32, 'e')])])
 
 
 if __name__ == '__main__':
-    test_timed_zip_agents()
-    test_timed_window()
+  unittest.main()


### PR DESCRIPTION
- I have modified a few more tests to fit the new convention as per this commit [here](https://github.com/sdeepaknarayanan/IoTPy/commit/d8e46df489cf4e6c8bcf0811a538830bc8b09614).
- I have not checked the tests that had pika and I am yet to put them together into one file. I hope to do that soon. 
- [source_test.py](https://github.com/sdeepaknarayanan/IoTPy/blob/master/tests/source_test.py) seems to be using an earlier version of IoTPy and I think that needs some changes. It seems to be using multicore from how I was using it last year at Caltech.
- I think there is a change in stream_test.py. [This](https://github.com/sdeepaknarayanan/IoTPy/blob/d8e46df489cf4e6c8bcf0811a538830bc8b09614/tests/stream_test.py#L207) particular line does not seem to be consistent with stream.py. stream.py mentions that both x.recent and num_in_memory have the same size.  I changed the stream_test.py currently to get the tests working. If there is a change in the main repository, we can change that too.
- I am a little confused about the tests with name VM. These seem to again be a part of an older version of IoTPy. I didn't see VM in IoTPy/concurrency. 